### PR TITLE
Add Sysbench OLTP benchmark for PostgreSQL (GMT usage scenario)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -6,6 +6,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: postgres
+      POSTGRES_HOST_AUTH_METHOD: trust
     ports:
       - "5432:5432"
   mariadb:
@@ -34,3 +35,10 @@ services:
   hammerdb:
     image: tpcorg/hammerdb:latest
     container_name: hammerdb_container
+
+  sysbench_container:
+    image: severalnines/sysbench
+    container_name: sysbench_container
+    depends_on:
+      - postgres
+    entrypoint: ["sleep", "infinity"]

--- a/usage_scenario_sysbench_pg.yml
+++ b/usage_scenario_sysbench_pg.yml
@@ -1,0 +1,78 @@
+---
+name: Sysbench Postgres benchmark
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: Benchmarks PostgreSQL with Sysbench OLTP (read/write)
+
+compose-file: !include compose.yml
+
+sci:
+  R_d: TPC-C SQL-op
+
+services:
+  mariadb: # empty key will remove the unused service
+  mysql: # empty key will remove the service
+
+flow:
+  - name: Create sbtest DB
+    container: postgres_container
+    commands:
+      - type: console
+        note: CREATE SBTEST DB
+        command: psql -U postgres -d postgres -c "CREATE DATABASE sbtest;"
+        shell: sh
+
+  - name: Prepare Sysbench Data
+    container: sysbench_container
+    commands:
+      - type: console
+        note: SYSBENCH PREPARE
+        shell: sh
+        command: >
+          sysbench oltp_read_write
+          --db-driver=pgsql
+          --pgsql-host=postgres_container
+          --pgsql-user=postgres
+          --pgsql-password=postgres
+          --pgsql-db=sbtest
+          --tables=10
+          --table-size=100000
+          prepare
+        log-stdout: true
+
+  - name: Run Sysbench Workload
+    container: sysbench_container
+    commands:
+      - type: console
+        note: SYSBENCH RUN
+        shell: sh
+        command: >
+          sysbench oltp_read_write
+          --db-driver=pgsql
+          --pgsql-host=postgres_container
+          --pgsql-user=postgres
+          --pgsql-password=postgres
+          --pgsql-db=sbtest
+          --tables=10
+          --table-size=100000
+          --time=60
+          --threads=4
+          run
+        log-stdout: true
+
+  - name: Cleanup Sysbench Data
+    container: sysbench_container
+    commands:
+      - type: console
+        note: SYSBENCH CLEANUP
+        shell: sh
+        command: >
+          sysbench oltp_read_write
+          --db-driver=pgsql
+          --pgsql-host=postgres_container
+          --pgsql-user=postgres
+          --pgsql-password=postgres
+          --pgsql-db=sbtest
+          --tables=10
+          --table-size=100000
+          cleanup
+        log-stdout: true


### PR DESCRIPTION
- Added Sysbench OLTP (read/write) usage scenario for PostgreSQL in GMT.
- Fixed compose + scenario flow: create sbtest DB before sysbench prepare.
- Verified successful GMT run and report generated.
Report example: http://metrics.green-coding.internal:9142/stats.html?id=8043fff0-492c-4135-a512-95e695a6ccf6
