### PR TITLE
Mysql: try to fixed mysql bug with update to 9.6 and delting old method of native password 

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -19,9 +19,8 @@ services:
     ports:
       - "3306:3306"
   mysql:
-    image: mysql:9.5.0-oraclelinux9
+    image: mysql:9.6.0-oraclelinux9
     container_name: mysql_container
-    command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_ROOT_PASSWORD: mysql
       MYSQL_DATABASE: mysql


### PR DESCRIPTION
Removes deprecated --default-authentication-plugin=mysql_native_password flag which was removed in MySQL 9.x, and bumps the image to 9.6.0.