### PR TITLE
Add MSSQL Server TPC-C benchmark support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+test/
+usage_scenario_*_test.yml

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:18.1-trixie
+    image: postgres:18.3-trixie
     container_name: postgres_container
     environment:
       POSTGRES_USER: postgres
@@ -9,7 +9,7 @@ services:
     ports:
       - "5432:5432"
   mariadb:
-    image: mariadb:12.1.2-noble
+    image: mariadb:12.2.2-noble
     container_name: mariadb_container
     environment:
       MYSQL_ROOT_PASSWORD: maria
@@ -21,7 +21,6 @@ services:
   mysql:
     image: mysql:9.5.0-oraclelinux9
     container_name: mysql_container
-    command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_ROOT_PASSWORD: mysql
       MYSQL_DATABASE: mysql
@@ -29,8 +28,14 @@ services:
       MYSQL_PASSWORD: mysql
     ports:
       - "3307:3306"
-
-
   hammerdb:
     image: tpcorg/hammerdb:latest
     container_name: hammerdb_container
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    container_name: mssql_container
+    environment:
+      ACCEPT_EULA: Y
+      MSSQL_SA_PASSWORD: Mssql1234!
+    ports:
+      - "1433:1433"

--- a/mssql/mssql_tprocc_buildschema.tcl
+++ b/mssql/mssql_tprocc_buildschema.tcl
@@ -1,0 +1,23 @@
+#!/bin/tclsh
+puts "SETTING CONFIGURATION"
+dbset db mssqls
+dbset bm TPC-C
+diset connection mssqls_tcp true
+diset connection mssqls_port 1433
+diset connection mssqls_azure false
+diset connection mssqls_encrypt_connection true
+diset connection mssqls_trust_server_cert true
+diset connection mssqls_linux_server mssql_container
+diset connection mssqls_uid sa
+diset connection mssqls_pass Mssql1234!
+diset connection mssqls_linux_authent sql
+diset connection mssqls_linux_odbc {ODBC Driver 18 for SQL Server}
+set vu [ numberOfCPUs ]
+set warehouse [ expr {$vu * 5} ]
+diset tpcc mssqls_count_ware $warehouse
+diset tpcc mssqls_num_vu $vu
+diset tpcc mssqls_dbase tpcc
+diset tpcc mssqls_raiseerror true
+puts "SCHEMA BUILD STARTED"
+buildschema
+puts "SCHEMA BUILD COMPLETED"

--- a/mssql/mssql_tprocc_deleteschema.tcl
+++ b/mssql/mssql_tprocc_deleteschema.tcl
@@ -1,0 +1,19 @@
+#!/bin/tclsh
+puts "SETTING CONFIGURATION"
+dbset db mssqls
+dbset bm TPC-C
+diset connection mssqls_tcp true
+diset connection mssqls_port 1433
+diset connection mssqls_azure false
+diset connection mssqls_encrypt_connection true
+diset connection mssqls_trust_server_cert true
+diset connection mssqls_linux_server mssql_container
+diset connection mssqls_uid sa
+diset connection mssqls_pass Mssql1234!
+diset connection mssqls_linux_authent sql
+diset connection mssqls_linux_odbc {ODBC Driver 18 for SQL Server}
+diset tpcc mssqls_dbase tpcc
+diset tpcc mssqls_raiseerror true
+puts "DROP SCHEMA STARTED"
+deleteschema
+puts "DROP SCHEMA COMPLETED"

--- a/mssql/mssql_tprocc_run.tcl
+++ b/mssql/mssql_tprocc_run.tcl
@@ -1,0 +1,34 @@
+#!/bin/tclsh
+puts "SETTING CONFIGURATION"
+dbset db mssqls
+dbset bm TPC-C
+diset connection mssqls_tcp true
+diset connection mssqls_port 1433
+diset connection mssqls_azure false
+diset connection mssqls_encrypt_connection true
+diset connection mssqls_trust_server_cert true
+diset connection mssqls_linux_server mssql_container
+diset connection mssqls_uid sa
+diset connection mssqls_pass Mssql1234!
+diset connection mssqls_linux_authent sql
+diset connection mssqls_linux_odbc {ODBC Driver 18 for SQL Server}
+diset tpcc mssqls_dbase tpcc
+diset tpcc mssqls_driver timed
+diset tpcc mssqls_rampup 2
+diset tpcc mssqls_duration 5
+diset tpcc mssqls_allwarehouse true
+diset tpcc mssqls_timeprofile true
+diset tpcc mssqls_raiseerror true
+loadscript
+puts "TEST STARTED"
+vuset vu vcpu
+vucreate
+tcstart
+tcstatus
+set jobid [ vurun ]
+vudestroy
+tcstop
+puts "TEST COMPLETE"
+set of [ open /tmp/mssql_tprocc w ]
+puts $of $jobid
+close $of

--- a/usage_scenario_mssql.yml
+++ b/usage_scenario_mssql.yml
@@ -1,0 +1,53 @@
+---
+name: HammerDB MSSQL benchmark
+author: Max Jahns
+description: Benchmarks SQL Server with HammerDB using TPC-C
+compose-file: !include compose.yml
+sci:
+  R_d: TPC-C SQL-op
+services:
+  postgres:
+  mariadb:
+  mysql:
+  cockroachdb:
+  oracle:
+  hammerdb:
+    depends_on:
+      mssql:
+        condition: service_started
+flow:
+  - name: Wait for SQL Server
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: Waiting for SQL Server to be ready
+        command: sleep 30
+        shell: sh
+        log-stdout: true
+  - name: Build Warehouses
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB BUILD
+        command: ./hammerdbcli auto /tmp/repo/mssql/mssql_tprocc_buildschema.tcl | tee /dev/stderr | awk '/System achieved [0-9]+ NOPM/ { match($0, /System achieved [0-9]+ NOPM/); printf("GMT_SCI_R=%s\n", substr($0, RSTART+16, RLENGTH-21)) }'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Query Warehouses
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB RUN
+        command: ./hammerdbcli auto /tmp/repo/mssql/mssql_tprocc_run.tcl | tee /dev/stderr | awk '/System achieved [0-9]+ NOPM/ { match($0, /System achieved [0-9]+ NOPM/); printf("GMT_SCI_R=%s\n", substr($0, RSTART+16, RLENGTH-21)) }'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Drop Warehouses
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB DROP
+        command: ./hammerdbcli auto /tmp/repo/mssql/mssql_tprocc_deleteschema.tcl | tee /dev/stderr | awk '/System achieved [0-9]+ NOPM/ { match($0, /System achieved [0-9]+ NOPM/); printf("GMT_SCI_R=%s\n", substr($0, RSTART+16, RLENGTH-21)) }'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true

--- a/usage_scenario_mssql.yml
+++ b/usage_scenario_mssql.yml
@@ -3,8 +3,6 @@ name: HammerDB MSSQL benchmark
 author: Max Jahns
 description: Benchmarks SQL Server with HammerDB using TPC-C
 compose-file: !include compose.yml
-sci:
-  R_d: TPC-C SQL-op
 services:
   postgres:
   mariadb:


### PR DESCRIPTION
Adds Microsoft SQL Server support for TPC-C benchmarking via HammerDB. Includes build, run and delete schema scripts and a GMT usage scenario. 

SQL Server needs ~30 seconds startup time which is handled via a sleep in the usage scenario.