### PR TITLE
Add Oracle Free Edition TPC-C benchmark support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+test/
+usage_scenario_*_test.yml

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:18.1-trixie
+    image: postgres:18.3-trixie
     container_name: postgres_container
     environment:
       POSTGRES_USER: postgres
@@ -9,7 +9,7 @@ services:
     ports:
       - "5432:5432"
   mariadb:
-    image: mariadb:12.1.2-noble
+    image: mariadb:12.2.2-noble
     container_name: mariadb_container
     environment:
       MYSQL_ROOT_PASSWORD: maria
@@ -21,7 +21,6 @@ services:
   mysql:
     image: mysql:9.5.0-oraclelinux9
     container_name: mysql_container
-    command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_ROOT_PASSWORD: mysql
       MYSQL_DATABASE: mysql
@@ -29,8 +28,16 @@ services:
       MYSQL_PASSWORD: mysql
     ports:
       - "3307:3306"
-
-
   hammerdb:
     image: tpcorg/hammerdb:latest
     container_name: hammerdb_container
+    environment:
+      LD_LIBRARY_PATH: /home/instantclient_21_18
+      ORACLE_HOME: /home/instantclient_21_18
+  oracle:
+    image: container-registry.oracle.com/database/free:latest
+    container_name: oracle_container
+    environment:
+      ORACLE_PWD: manager
+    ports:
+      - "1521:1521"

--- a/oracle/oracle_tprocc_buildschema.tcl
+++ b/oracle/oracle_tprocc_buildschema.tcl
@@ -1,0 +1,26 @@
+#!/bin/tclsh
+puts "SETTING CONFIGURATION"
+dbset db ora
+dbset bm TPC-C
+diset connection system_user system
+diset connection system_password manager
+diset connection instance //oracle_container:1521/freepdb1
+set vu [ numberOfCPUs ]
+set warehouse [ expr {$vu * 5} ]
+diset tpcc count_ware $warehouse
+diset tpcc num_vu $vu
+diset tpcc tpcc_user tpcc
+diset tpcc tpcc_pass tpcc
+diset tpcc tpcc_def_tab users
+diset tpcc tpcc_def_temp temp
+if { $warehouse >= 200 } {
+    diset tpcc partition true
+    diset tpcc hash_clusters true
+    diset tpcc tpcc_ol_tab users
+} else {
+    diset tpcc partition false
+    diset tpcc hash_clusters false
+}
+puts "SCHEMA BUILD STARTED"
+buildschema
+puts "SCHEMA BUILD COMPLETED"

--- a/oracle/oracle_tprocc_deleteschema.tcl
+++ b/oracle/oracle_tprocc_deleteschema.tcl
@@ -1,0 +1,12 @@
+#!/bin/tclsh
+puts "SETTING CONFIGURATION"
+dbset db ora
+dbset bm TPC-C
+diset connection system_user system
+diset connection system_password manager
+diset connection instance //oracle_container:1521/freepdb1
+diset tpcc tpcc_user tpcc
+diset tpcc tpcc_pass tpcc
+puts "DROP SCHEMA STARTED"
+deleteschema
+puts "DROP SCHEMA COMPLETED"

--- a/oracle/oracle_tprocc_run.tcl
+++ b/oracle/oracle_tprocc_run.tcl
@@ -1,0 +1,29 @@
+#!/bin/tclsh
+puts "SETTING CONFIGURATION"
+dbset db ora
+dbset bm TPC-C
+diset connection system_user system
+diset connection system_password manager
+diset connection instance //oracle_container:1521/freepdb1
+diset tpcc tpcc_user tpcc
+diset tpcc tpcc_pass tpcc
+diset tpcc ora_driver timed
+diset tpcc total_iterations 10000000
+diset tpcc rampup 2
+diset tpcc duration 5
+diset tpcc ora_timeprofile true
+diset tpcc allwarehouse true
+diset tpcc checkpoint false
+loadscript
+puts "TEST STARTED"
+vuset vu vcpu
+vucreate
+tcstart
+tcstatus
+set jobid [ vurun ]
+vudestroy
+tcstop
+puts "TEST COMPLETE"
+set of [ open /tmp/oracle_tprocc w ]
+puts $of $jobid
+close $of

--- a/usage_scenario_oracle.yml
+++ b/usage_scenario_oracle.yml
@@ -4,8 +4,6 @@ author: Max Jahns
 description: Benchmarks Oracle with HammerDB using TPC-C
 compose-file: !include compose.yml
 ignore-unsupported-compose: true
-sci:
-  R_d: TPC-C SQL-op
 services:
   postgres:
   mariadb:

--- a/usage_scenario_oracle.yml
+++ b/usage_scenario_oracle.yml
@@ -1,0 +1,56 @@
+---
+name: HammerDB Oracle benchmark
+author: Max Jahns
+description: Benchmarks Oracle with HammerDB using TPC-C
+compose-file: !include compose.yml
+ignore-unsupported-compose: true
+sci:
+  R_d: TPC-C SQL-op
+services:
+  postgres:
+  mariadb:
+  mysql:
+  mssql:
+  cockroachdb:
+  oracle:
+    image: container-registry.oracle.com/database/free:latest
+  hammerdb:
+    depends_on:
+      oracle:
+        condition: service_started
+flow:
+  - name: Wait for Oracle
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: Waiting for Oracle to be ready
+        command: sleep 120
+        shell: sh
+        log-stdout: true
+  - name: Build Warehouses
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB BUILD
+        command: ./hammerdbcli auto /tmp/repo/oracle/oracle_tprocc_buildschema.tcl | tee /dev/stderr | awk '/System achieved [0-9]+ NOPM/ { match($0, /System achieved [0-9]+ NOPM/); printf("GMT_SCI_R=%s\n", substr($0, RSTART+16, RLENGTH-21)) }'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Query Warehouses
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB RUN
+        command: ./hammerdbcli auto /tmp/repo/oracle/oracle_tprocc_run.tcl | tee /dev/stderr | awk '/System achieved [0-9]+ NOPM/ { match($0, /System achieved [0-9]+ NOPM/); printf("GMT_SCI_R=%s\n", substr($0, RSTART+16, RLENGTH-21)) }'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Drop Warehouses
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB DROP
+        command: ./hammerdbcli auto /tmp/repo/oracle/oracle_tprocc_deleteschema.tcl | tee /dev/stderr | awk '/System achieved [0-9]+ NOPM/ { match($0, /System achieved [0-9]+ NOPM/); printf("GMT_SCI_R=%s\n", substr($0, RSTART+16, RLENGTH-21)) }'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true


### PR DESCRIPTION
Adds Oracle Free Edition support for TPC-C benchmarking via HammerDB. Key changes:

- Uses freepdb1 PDB instead of CDB (FREE) to allow normal user creation ( otherwise using Tcp-c is not possible)
- Connection string: //oracle_container:1521/freepdb1
- LD_LIBRARY_PATH and ORACLE_HOME set for Oracle Instant Client
- 120 second startup wait in usage scenario
- Oracle Container Registry login required (free account)