### PR TITLE
Add T1 (envelope-sized) and T2 (workload-aware) tuning tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,28 @@ We currently run five benchmarks:
 
 The three BenchBase benchmarks cover **5** engines — there is no Db2 BenchBase profile, so Db2 has TPC-C/TPC-H only.
 
+## Tuning tiers
+
+To study energy vs. tuning effort, each scenario comes in tiers. Tier files sit next to the default and share the
+default's flow (only the *engine configuration* changes between tiers), so `run_on_cluster.py` discovers them
+automatically:
+
+- **T0 — default**: `benchmarks/<benchmark>/<db>.yml` (stock container).
+- **T1 — envelope-sized**: `benchmarks/<benchmark>/<db>.t1.yml` — each vendor's own rules-of-thumb sized to the fixed
+  4-CPU / 8-GB container; durability left at default so the T0→T1 delta is pure resource sizing.
+
+```sh
+# default vs. envelope-sized, Postgres TPC-C
+./run_on_cluster.py --machine-id N --filter 'tpcc/pg.yml'
+./run_on_cluster.py --machine-id N --filter 'tpcc/pg.t1.yml'
+./run_on_cluster.py --machine-id N -t 0                    # every T0 scenario
+./run_on_cluster.py --machine-id N -t 1                    # every T1 scenario
+./run_on_cluster.py --machine-id N -t 0 -n                 # preview without submitting
+```
+
+See [TUNING.md](TUNING.md) for per-engine settings, provenance, threats to validity (Oracle Free / Db2 Community
+edition caps, OOM headroom, Oracle/Db2 verify-on-first-run), and the planned T2 (advisor) and T3 (auto-tuner) tiers.
+
 ## Db2 setup
 
 Db2 needs a one-time prep the other engines don't. The `tpcorg/hammerdb` image has no Db2 client, and

--- a/TUNING.md
+++ b/TUNING.md
@@ -1,0 +1,302 @@
+# Tuning tiers
+
+This repo measures DBMS energy with a **standardised, symmetric optimisation
+procedure** rather than a hand-picked per-engine optimum. The thing we hold
+constant across engines is the *procedure* (same objective, same search space,
+same budget, same fixed resource envelope), so the comparison survives the
+"you tuned engine X better than engine Y" critique. Each step up the ladder is
+reproducible because it is mechanical or algorithmic, not artisanal.
+
+## The ladder
+
+| Tier | Name | What changes | Status |
+|------|------|--------------|--------|
+| **T0** | Default / out-of-the-box | Stock container, nothing tuned but what's needed to run | shipped (`benchmarks/<bench>/<db>.yml`) |
+| **T1** | Envelope-sized | Each vendor's own rules-of-thumb, evaluated at the engine's effective limit `M` (see "How each T1 number is derived") | shipped (`benchmarks/<bench>/<db>.t1.yml`) |
+| **T2** | Workload-aware | Indexes / partitioning / parallelism + curated config (+ native advisors where usable) | **shipped** — all 5 benchmarks (29 `.t2`/`.t2col` files) |
+| **T2+** | Columnar sub-tier | Best-per-engine columnar (SQL Server columnstore, Db2 BLU) on the analytical benchmarks | shipped (TPC-H `mssql.t2col`, `db2.t2col`) |
+| **T3** | Auto-tuned | One black-box optimiser (e.g. Optuna TPE) over the common knob space, fixed trial budget, objective = energy | planned |
+
+Reporting energy at every rung gives the paper an effort-attribution story:
+*how much energy each level of tuning effort actually buys.*
+
+T1 currently ships for **all five benchmarks** — TPC-C, TPC-H (HammerDB, 6 engines incl. Db2) and Wikipedia, YCSB,
+CH-benCHmark (BenchBase, 5 engines; no Db2 profile) — i.e. 27 `*.t1.yml` files. The engine config for a given engine is
+the same across all five (T1 is hardware-sized), so only the metric and the shared flow differ per file.
+
+## Objective function
+
+Primary: **energy per unit of work** — Joules per TPC-C SQL-op (NOPM-derived),
+per TPC-H query, and per Wikipedia/YCSB/CH-benCHmark request (BenchBase
+`measuredRequests`; for CH-benCHmark that count is OLTP txns + OLAP queries).
+This is already the SCI functional unit in each scenario. Always **integrate
+power over the whole run**; never compare on peak watts or wall-clock alone
+(race-to-idle makes both misleading).
+
+Measure both meters and report both:
+
+- **Wall / full-system meter** — the honest total; **T3 optimises against this.**
+- **RAPL (CPU+DRAM)** — blind to storage and NIC energy. Track the wall/RAPL
+  ratio per engine and tier: the gap is the energy invisible to CPU-only
+  telemetry and is expected to be largest for I/O-bound TPC-H.
+
+## Fixed envelope
+
+Every engine container gets `cpus: 4` and `mem_limit: 8g` (see `compose.yml`).
+T1 sizes each engine to use *that* envelope well — memory is sized **relative to
+the container's cgroup limit, not host RAM**, because a buffer above the cgroup
+limit triggers OOM-kill / swap and wrecks the energy numbers.
+
+One engine cannot actually reach that envelope, and this matters more than any
+individual knob value: **Oracle Database Free is licence-capped at ~2 GB of
+database RAM (SGA+PGA) and 2 CPU threads.** Every other engine fits — Db2
+Community (16 GB / 4 cores), SQL Server Developer (full), and PostgreSQL / MySQL
+/ MariaDB (unrestricted). So define the **effective memory limit**
+
+> `M = min(8 GB cgroup, edition cap)` → 8 GB for every engine except Oracle Free, where `M = 2 GB`.
+
+Every T1 memory number is a vendor rule-of-thumb evaluated at `M`. **The quantity
+held constant across engines is the procedure — rule applied to `M` — not the
+resulting byte counts.** Two engines landing on different numbers is the expected
+output of the procedure, not evidence that it was applied unevenly.
+
+## T1 settings and provenance
+
+T1 is **hardware-sized and workload-agnostic** — the same engine config is used
+for TPC-C and TPC-H (the `.t1.yml` files for a given engine are identical except
+for the metric and the included flow; `check_repo.py` check 4 enforces this,
+comments included). Workload specialisation is deferred to T2.
+**Durability is left at each engine's default** (e.g. PostgreSQL
+`synchronous_commit=on`, InnoDB `flush_log_at_trx_commit=1`) so the T0→T1 delta
+is pure resource sizing, not a safety trade.
+
+| Dimension | PostgreSQL | MySQL / MariaDB | SQL Server | Oracle Free | Db2 |
+|-----------|-----------|------------------|------------|-------------|-----|
+| Buffer / cache | `shared_buffers=2GB` (25%) + `effective_cache_size=6GB` | `innodb_buffer_pool_size=5G` (~62%) | `MSSQL_MEMORY_LIMIT_MB=5120` (max server memory) | `sga_target=1300M` (capped, see below) | STMM auto within instance memory |
+| Work / sort mem | `work_mem=16MB`, `maintenance_work_mem=512MB` | n/a (server-managed) | (auto) | `pga_aggregate_target=500M` | `SORTHEAP/SHEAPTHRES_SHR AUTOMATIC` |
+| Parallelism | `max_parallel_workers=4`, `..._per_gather=2` | (limited) | deferred to T2 (MAXDOP) | capped at 2 threads | (STMM / default) |
+| Redo / WAL | `max_wal_size=4GB`, `wal_buffers=16MB` | `innodb_redo_log_capacity=2G` (MySQL) / `innodb_log_file_size=2G` (MariaDB) | default | default | default |
+| Storage I/O | `random_page_cost=1.1`, `effective_io_concurrency=200` | `innodb_flush_method=O_DIRECT`, `innodb_io_capacity(_max)=2000/4000` | default | default | default |
+
+Rules-of-thumb follow each vendor's published guidance (PostgreSQL 25%/75%
+shared_buffers/effective_cache_size, the PGTune "OLTP" profile shape; InnoDB
+buffer pool 50–75% of RAM with O_DIRECT; SQL Server "max server memory" leaving
+~25–35% for the OS/SQLOS).
+
+### Why the T1 files look so different from each other
+
+Opening `<bench>/mysql.t1.yml` next to `<bench>/oracle.t1.yml` shows a nine-line
+list of `--innodb-*` flags beside a retrying `sqlplus` script. That is the most
+divergent pair in the repo, and **three independent things vary between them** —
+only the third is about tuning at all:
+
+1. **Knob namespace.** There is no cross-engine "buffer pool size" knob, because
+   the caches are not the same object. InnoDB with `O_DIRECT` bypasses the OS
+   page cache, so its buffer pool *is* the only cache and takes ~62% of `M`
+   directly. PostgreSQL reads *through* the page cache, so its vendor rule is a
+   25% `shared_buffers` plus a 75% `effective_cache_size` — the latter is a
+   **planner hint describing memory Postgres does not allocate.** Db2 exposes no
+   number at all; STMM sizes it at runtime. Forcing these to the same literal
+   would be the actual methodological error: `shared_buffers=5GB` would
+   double-buffer against the page cache and perform *worse*.
+2. **Injection mechanism.** PostgreSQL / MySQL / MariaDB accept `-c key=val` on
+   the entrypoint; SQL Server takes an env var; Oracle and Db2 expose no
+   command-flag config at all and need a `flow-prepend:` step running
+   `ALTER SYSTEM` / `db2 update db cfg`. Pure plumbing, zero methodology — see
+   "How T1 is injected per engine" below.
+3. **Effective limit `M`.** Oracle Free is sized against its 2-GB licence cap,
+   every other engine against the 8-GB cgroup. This is the one difference that
+   genuinely threatens comparability, and it is a property of the *edition*, not
+   of how hard we tuned. See "Threats to validity".
+
+### How each T1 number is derived
+
+Every literal in every `*.t1.yml` is recomputable from `(M, cores) = (8 GB, 4)` —
+or `(2 GB, 2)` for Oracle Free — plus the vendor's published rule. Nothing below
+was hand-picked or search-tuned; there is no per-engine trial-and-error in T1
+(that is what T3 is for).
+
+| Engine | `M` | Vendor rule | Arithmetic | Literal in `*.t1.yml` |
+|--------|-----|-------------|-----------|----------------------|
+| PostgreSQL | 8 GB | `shared_buffers` = 25% of RAM; `effective_cache_size` = 75% (planner hint, not an allocation) | 0.25 × 8 GB; 0.75 × 8 GB | `shared_buffers=2GB`, `effective_cache_size=6GB` |
+| MySQL | 8 GB | InnoDB buffer pool 50–75% of RAM under `O_DIRECT` (sole cache) | 0.625 × 8 GB (mid-band) | `innodb_buffer_pool_size=5G` |
+| MySQL | 8 GB | ≥ 1 GB per buffer-pool instance | 5 G ÷ 4 = 1.25 GB each | `innodb_buffer_pool_instances=4` |
+| MariaDB | 8 GB | same InnoDB rule (instances are a no-op on modern MariaDB) | 0.625 × 8 GB | `innodb_buffer_pool_size=5G` |
+| SQL Server | 8 GB | "max server memory", leaving 25–35% to OS/SQLOS | 0.625 × 8192 MB, leaving **37.5%** ¹ | `MSSQL_MEMORY_LIMIT_MB=5120` |
+| Oracle Free | **2 GB** | fill the licensed database RAM, keeping headroom; SGA:PGA ≈ 70:30 mixed | 1300 + 500 = 1800 MB of 2048 MB (~88%, ~250 MB headroom) | `sga_target=1300M`, `pga_aggregate_target=500M` |
+| Db2 | 8 GB | leave STMM on, memory areas `AUTOMATIC` | none — sized at runtime ² | `SELF_TUNING_MEM ON`, `DATABASE_MEMORY/SORTHEAP/SHEAPTHRES_SHR AUTOMATIC` |
+
+Core-derived and storage-derived knobs use the same treatment: parallelism is set
+to the 4-core count (`max_worker_processes=4`, `max_parallel_workers=4`), and all
+engines assume the same SSD-class storage (`random_page_cost=1.1`,
+`effective_io_concurrency=200`, `innodb_io_capacity=2000/4000`).
+
+**Deviations, stated explicitly** (a reviewer should be able to find every place
+the arithmetic does *not* follow the vendor band):
+
+- ¹ **SQL Server leaves 37.5%, not the recommended 25–35%.** Deliberate: the
+  vendor band assumes a host that swaps under pressure, whereas a hard cgroup
+  limit turns an over-commit into a silent OOM-kill that ruins the run.
+- ² **Db2 has no derivable literal** because its vendor rule *is* "leave it
+  automatic". The one lever that would pin STMM to the cgroup (`INSTANCE_MEMORY`)
+  requires an instance restart and ships commented-out and opt-in.
+- **Oracle sizes to 88% of `M`, not ~62%.** Its 2-GB cap applies to SGA+PGA only
+  (process and OS overhead sit outside it), so the fraction is not comparable
+  with the InnoDB/SQL Server percentages, which are fractions of a cgroup that
+  must *also* hold the server process.
+
+### How T1 is injected per engine
+
+- **PostgreSQL / MySQL / MariaDB** — config flags passed via the service
+  `command:` (the official entrypoints forward `-c key=val` / `--key=val`).
+  *Verified locally: each image boots to "ready to accept connections" with the
+  exact T1 flags.*
+- **SQL Server** — `max server memory` via the `MSSQL_MEMORY_LIMIT_MB` env var.
+- **Oracle / Db2** — no command-flag config, so a `flow-prepend:` step runs
+  `ALTER SYSTEM` (Oracle, in `oracle_container`) / `db2 update db cfg` (Db2, in
+  `db2_container`) before the workload. These steps retry until the DB answers,
+  echo the applied config to stdout, and never fail the run.
+
+## T2 settings and provenance
+
+T2 is **workload-aware** and builds on T1. Per the chosen policy it has two
+sub-tiers: **T2 (common)** = same logical row-store design for every engine;
+**T2+ (columnar)** = the strongest columnar design each capable engine offers, on
+the analytical benchmarks only. Tuning is **curated workload-aware best-practice
+for all engines, plus each engine's native advisor where one runs** (see table).
+
+T2 touches **three injection points** (vs T1's single config point):
+
+1. **DB config** (same mechanism as T1). OLAP (TPC-H, CH-benCHmark): large
+   `work_mem`/sort memory, per-query parallelism = core count, higher statistics
+   target, JIT. OLTP/serving (TPC-C, YCSB, Wikipedia): mostly T1 + stats, small
+   deltas. *Verified: the pg OLAP config boots.*
+2. **Driver settings** — HammerDB `*.t2.tcl` / `*.t2col.tcl` script variants
+   (`db/<db>/<bench>/`): parallel degree / MAXDOP raised to the 4-core count;
+   columnstore (`mssqls_colstore true`) for T2+. BenchBase has no driver knobs to
+   vary (the workload is fixed in the XML), so its T2 is config-only for
+   Wikipedia/YCSB and config-only HTAP balancing for CH-benCHmark.
+3. **Post-load "optimize" step** — a mid-flow step in the DB container (after the
+   load, before the measured run): `ANALYZE` / `UPDATE STATISTICS` / `runstats`,
+   curated indexes, and the native advisor where available. This is used where
+   the benchmark has a shipped post-load DDL/statistics step; config-only T2
+   scenarios keep the base `flow:` include.
+
+**Parallelism is treated as a per-tier-fair tuning lever**, not a fixed fairness
+invariant: every engine's T2 uses degree = core count, so the comparison stays
+fair *within* the tier. `check_repo.py` was made **tier-aware** (it buckets driver
+scripts by the filename suffix — `base`/`t1`/`t2`/`t2col` — and checks fairness
+knobs within each tier) so raising the degree in T2 no longer trips it.
+
+File naming: `benchmarks/<bench>/<db>.t2.yml` (common), `…<db>.t2col.yml`
+(columnar); driver variants `…_<role>.t2.tcl` / `…_<role>.t2col.tcl`.
+
+**Native advisor availability (Linux containers):**
+
+| Engine | Native advisor | Usable here? |
+|--------|----------------|--------------|
+| PostgreSQL | none built-in | curated only |
+| MySQL / MariaDB | MySQLTuner (config) | yes (perl script) |
+| SQL Server | Database Engine Tuning Advisor | **no — Windows-only** → curated only |
+| Oracle Free | SQL Tuning Advisor / ADDM | **no — Tuning Pack + Free caps** → curated only |
+| Db2 | `db2advis` (Design Advisor) | yes (CLP) |
+
+**Columnar (T2+) support:** SQL Server clustered columnstore — shipped (TPC-H);
+Db2 BLU column-organized — planned; PostgreSQL / MySQL / MariaDB / Oracle Free —
+none in core/edition, so they get the row-store T2 only.
+
+**Shipped & validated across the matrix** — 29 `.t2`/`.t2col` files; all 83
+scenarios pass GMT's SchemaChecker and `check_repo.py` (tier-aware); the pg OLAP
+config boots; TCL variants diff cleanly from the working T0.
+
+- **TPC-H** (analytical, the lever-rich tier): pg/maria/mysql/oracle/db2 T2
+  (OLAP config; degree=4 where the engine parallelises — pg, oracle; MySQL/MariaDB
+  use big session buffers instead; a post-load optimize step adds curated indexes +
+  stats) and **T2+ columnar** for SQL Server (columnstore) and Db2 (BLU).
+- **TPC-C** (OLTP): config-only T2 (pg aggressive autovacuum; MySQL/MariaDB
+  write-path tuning), shares the T0 flow.
+- **Wikipedia / YCSB** (serving) & **CH-benCHmark** (HTAP): config-delta T2
+  (CH gets OLAP-leaning config), shares the T0 flow.
+
+What's intentionally **thin or deferred** (honest findings, documented per file):
+
+- **OLTP/serving T2 ≈ T1 for SQL Server / Oracle Free / Db2** — those engines have
+  no injectable workload-specific lever there (SQL Server config needs `sqlcmd`,
+  absent in the Linux image; Oracle Free is capped; Db2 already self-tunes).
+- **CH-benCHmark columnar** (SQL Server NCCI) is **deferred** — creating it
+  post-load needs `sqlcmd`, which the image lacks.
+- **Native advisor steps** (`db2advis`, MySQLTuner) are **not yet wired in** — they
+  remain the documented next supplement; current T2 is curated tuning.
+
+⚠️ VERIFY-on-first-run items (all optimize steps are non-fatal so they can't break
+a run): the curated `CREATE INDEX` names assume HammerDB's standard TPC-H schema;
+Oracle/Db2 optimize + Db2 BLU enablement (`DB2_WORKLOAD=ANALYTICS` + restart)
+could not be exercised offline. Check each "Optimize schema"/"Tune"/"Enable" step's
+stdout in the run log.
+
+## Threats to validity / caveats
+
+- **Edition caps confound cross-engine comparison — this is the headline caveat.**
+  Oracle Database **Free** is licence-capped at ~**2 GB RAM / 2 CPU threads** — it
+  *cannot* use the 8-GB / 4-CPU envelope, so its T0→T1 delta will be small (near
+  noise) and its **absolute J/op is not comparable on equal-hardware terms** with
+  the other engines. This, not the differing knob values, is the real limit on
+  cross-engine comparability: the tuning *procedure* is uniform (see "How each T1
+  number is derived"), but Oracle's effective limit `M` is 4× smaller. Db2
+  **Community** (16 GB / 4 cores) and SQL Server **Developer** (full) fit the
+  envelope; PostgreSQL/MySQL/MariaDB are unrestricted. Disclose this in the paper,
+  and prefer within-engine T0→T1→T2 deltas over cross-engine absolutes wherever
+  Oracle Free is in the comparison.
+- **Oracle / Db2 T1 are best-effort and need one VERIFY run.** Could not be
+  executed offline. Check the "Tune …" flow step's stdout in the run log to
+  confirm the parameters actually applied:
+  - Oracle: under Automatic Memory Management (`memory_target>0`) the SGA/PGA
+    `ALTER`s are skipped (would need a restart).
+  - Db2: default already self-tunes (STMM). The meaningful envelope lever —
+    capping `INSTANCE_MEMORY` to the cgroup so STMM doesn't size against
+    mis-detected host RAM — needs an instance restart and is left as a commented,
+    opt-in block in `*/db2.t1.yml`.
+- **OOM risk.** With a hard cgroup limit, an oversized buffer triggers an
+  OOM-kill that silently ruins a run. If MySQL/MariaDB/MSSQL get killed, drop the
+  buffer to ~4 G / 4096 MB.
+- **Idle load-driver container.** The unused driver is left running in some
+  scenarios — `benchbase` idles in the HammerDB TPC-C/TPC-H scenarios (they don't
+  remove it). It adds a small constant to every such measurement: it cancels in
+  the T0→T1 delta but inflates absolute numbers. Add an empty `benchbase:` key to
+  those scenarios if absolute energy matters.
+- **`compose.yml` is duplicated** into every benchmark dir (`benchmarks/tpcc/`,
+  `benchmarks/tpch/`, `benchmarks/wikipedia/`, `benchmarks/ycsb/`,
+  `benchmarks/chbenchmark/`) because GMT only allows `!include` of files in the
+  scenario's own directory (it rejects `../compose.yml`). Treat the root
+  `compose.yml` as the source of truth and keep the copies in sync:
+  `for d in tpcc tpch wikipedia ycsb chbenchmark; do cp compose.yml "benchmarks/$d/compose.yml"; done`
+  (`check_repo.py` enforces they stay byte-identical).
+
+## Running a tier
+
+Scenarios are auto-discovered by `run_on_cluster.py`; filter by tier:
+
+```sh
+# Postgres TPC-H across tiers: default -> envelope -> workload-aware
+./run_on_cluster.py --machine-id N -t 0 --filter 'tpch/pg.yml'
+./run_on_cluster.py --machine-id N -t 1 --filter 'tpch/pg.t1.yml'
+./run_on_cluster.py --machine-id N -t 2 --filter 'tpch/pg.t2.yml'
+
+# every T2/T2+ scenario, or just the columnar sub-tier
+./run_on_cluster.py --machine-id N -t 2
+./run_on_cluster.py --machine-id N --filter 'benchmarks/*/*.t2col.yml'
+
+# preview selected runs without submitting
+./run_on_cluster.py --machine-id N -t 0 -n
+```
+
+## Roadmap
+
+- **T2** — see "T2 settings and provenance" above: reference shipped for TPC-H
+  (pg + mssql, common + columnar); remaining engines/benchmarks per the scale-out
+  plan there.
+- **T3** — one Optuna/SMAC loop over the common knob space, objective = wall-meter
+  J/op, fixed trial budget per (engine × benchmark), reusing the GMT submit
+  `APIClient` from `run_on_cluster.py`. Because each trial is a full cluster run
+  (git-gated, async, minutes each), use a sample-efficient optimiser and a small
+  (~8–12 knob) search space.

--- a/benchmarks/chbenchmark/maria.t1.yml
+++ b/benchmarks/chbenchmark/maria.t1.yml
@@ -1,0 +1,46 @@
+---
+name: BenchBase MariaDB CH-benCHmark benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  CH-benCHmark HTAP (TPC-C + TPC-H, BenchBase) on MariaDB, tuning tier T1
+  (envelope-sized). Same hardware-sized InnoDB config as tpcc/maria.t1.yml; durability at
+  default. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  chbenchmark_requests:
+    unit: CH-benCHmark request
+    sci: true
+
+services:
+  # T1 tuning: flags appended to mariadbd by the image entrypoint. Merged over
+  # compose.yml. (buffer_pool_instances is omitted: a no-op on modern MariaDB.)
+  #
+  # Every literal below is recomputable from the 4-CPU / 8-GB envelope alone --
+  # see the derivation table in TUNING.md ("How each T1 number is derived").
+  # Same InnoDB rule as mysql.t1.yml: O_DIRECT makes the buffer pool the only
+  # cache, so it takes ~62% of the cgroup directly (vendor band: 50-75% of RAM).
+  mariadb:
+    command:
+      - "--innodb-buffer-pool-size=5G"           # 62.5% of the 8-GB cgroup
+      - "--innodb-log-file-size=2G"              # redo log sizing
+      - "--innodb-flush-method=O_DIRECT"         # avoid double-buffering w/ page cache
+      - "--innodb-flush-log-at-trx-commit=1"     # full durability (engine default, explicit)
+      - "--innodb-io-capacity=2000"              # SSD-class
+      - "--innodb-io-capacity-max=4000"          # SSD-class
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+  postgres: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase: # load driver; wait for the database to be healthy first
+    depends_on:
+      mariadb:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['maria.yml', 'flow']

--- a/benchmarks/chbenchmark/maria.t2.yml
+++ b/benchmarks/chbenchmark/maria.t2.yml
@@ -1,0 +1,43 @@
+---
+name: BenchBase MariaDB CH-benCHmark benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  CH-benCHmark (BenchBase, HTAP) on MariaDB, tuning tier T2. T1 InnoDB sizing + OLAP
+  session buffers + OLTP write-path tuning. Config-only; shares the T0 flow.
+  See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  chbenchmark_requests:
+    unit: CH-benCHmark request
+    sci: true
+
+services:
+  mariadb:
+    command:
+      - "--innodb-buffer-pool-size=5G"
+      - "--innodb-log-file-size=2G"
+      - "--innodb-flush-method=O_DIRECT"
+      - "--innodb-flush-log-at-trx-commit=1"
+      - "--innodb-io-capacity=2000"
+      - "--innodb-io-capacity-max=4000"
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+      - "--join-buffer-size=128M"
+      - "--sort-buffer-size=32M"
+      - "--tmp-table-size=512M"
+      - "--max-heap-table-size=512M"
+      - "--innodb-purge-threads=4"
+  postgres: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase:
+    depends_on:
+      mariadb:
+        condition: service_healthy
+
+flow: !include ['maria.yml', 'flow']

--- a/benchmarks/chbenchmark/mssql.t1.yml
+++ b/benchmarks/chbenchmark/mssql.t1.yml
@@ -1,0 +1,40 @@
+---
+name: BenchBase Microsoft SQL Server CH-benCHmark benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  CH-benCHmark HTAP (TPC-C + TPC-H, BenchBase) on Microsoft SQL Server, tuning tier T1
+  (envelope-sized). max server memory via MSSQL_MEMORY_LIMIT_MB, as in tpcc/mssql.t1.yml.
+  See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  chbenchmark_requests:
+    unit: CH-benCHmark request
+    sci: true
+
+services:
+  # T1 tuning: merged onto compose.yml's mssql environment (ACCEPT_EULA etc. kept).
+  #
+  # SQL Server manages its own buffer cache, so "max server memory" is the only
+  # envelope lever here; MAXDOP / cost-threshold are workload-specific -> T2.
+  # See the derivation table in TUNING.md ("How each T1 number is derived").
+  # Deliberate deviation from the vendor rule (leave 25-35% of RAM to the OS and
+  # SQLOS): we leave 37.5%, because under a hard cgroup limit an over-commit is a
+  # silent OOM-kill, not a swap slowdown.
+  mssql:
+    environment:
+      MSSQL_MEMORY_LIMIT_MB: "5120"   # max server memory; 62.5% of the 8-GB cgroup
+  postgres: # unused — empty key removes the service
+  mariadb: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase: # load driver; wait for the database to be healthy first
+    depends_on:
+      mssql:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['mssql.yml', 'flow']

--- a/benchmarks/chbenchmark/mssql.t2.yml
+++ b/benchmarks/chbenchmark/mssql.t2.yml
@@ -1,0 +1,33 @@
+---
+name: BenchBase MSSQL CH-benCHmark benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  CH-benCHmark (BenchBase, HTAP) on SQL Server, tuning tier T2. The natural T2+ for
+  SQL Server HTAP would be a nonclustered columnstore index on the analytical
+  tables, but creating it post-load needs sqlcmd (absent in the Linux image) and
+  BenchBase won't emit it — so that columnar variant is deferred. Injectable lever
+  is max server memory (set in T1): CONFIG-PARITY (thin) T2 = T1. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  chbenchmark_requests:
+    unit: CH-benCHmark request
+    sci: true
+
+services:
+  mssql:
+    environment:
+      MSSQL_MEMORY_LIMIT_MB: "5120"
+  postgres: # unused — empty key removes the service
+  mariadb: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase:
+    depends_on:
+      mssql:
+        condition: service_healthy
+
+flow: !include ['mssql.yml', 'flow']

--- a/benchmarks/chbenchmark/mysql.t1.yml
+++ b/benchmarks/chbenchmark/mysql.t1.yml
@@ -1,0 +1,47 @@
+---
+name: BenchBase MySQL CH-benCHmark benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  CH-benCHmark HTAP (TPC-C + TPC-H, BenchBase) on MySQL, tuning tier T1
+  (envelope-sized). Same hardware-sized InnoDB config as tpcc/mysql.t1.yml; durability at
+  default. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  chbenchmark_requests:
+    unit: CH-benCHmark request
+    sci: true
+
+services:
+  # T1 tuning: flags appended to mysqld by the official image entrypoint (it
+  # prepends `mysqld` when the command starts with `-`). Merged over compose.yml.
+  #
+  # Every literal below is recomputable from the 4-CPU / 8-GB envelope alone --
+  # see the derivation table in TUNING.md ("How each T1 number is derived").
+  # InnoDB with O_DIRECT owns the only page cache, so the buffer pool takes ~62%
+  # of the cgroup directly (vendor band: 50-75% of RAM).
+  mysql:
+    command:
+      - "--innodb-buffer-pool-size=5G"           # 62.5% of the 8-GB cgroup
+      - "--innodb-buffer-pool-instances=4"       # 5G / 4 = 1.25 GB each (>= 1 GB rule)
+      - "--innodb-redo-log-capacity=2G"          # MySQL 8.0.30+/9.x redo sizing
+      - "--innodb-flush-method=O_DIRECT"         # avoid double-buffering w/ page cache
+      - "--innodb-flush-log-at-trx-commit=1"     # full durability (engine default, explicit)
+      - "--innodb-io-capacity=2000"              # SSD-class
+      - "--innodb-io-capacity-max=4000"          # SSD-class
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+  postgres: # unused — empty key removes the service
+  mariadb: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase: # load driver; wait for the database to be healthy first
+    depends_on:
+      mysql:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['mysql.yml', 'flow']

--- a/benchmarks/chbenchmark/mysql.t2.yml
+++ b/benchmarks/chbenchmark/mysql.t2.yml
@@ -1,0 +1,44 @@
+---
+name: BenchBase MySQL CH-benCHmark benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  CH-benCHmark (BenchBase, HTAP) on MySQL, tuning tier T2. T1 InnoDB sizing + OLAP
+  session buffers (for the analytical queries) + OLTP write-path tuning.
+  Config-only; shares the T0 flow. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  chbenchmark_requests:
+    unit: CH-benCHmark request
+    sci: true
+
+services:
+  mysql:
+    command:
+      - "--innodb-buffer-pool-size=5G"
+      - "--innodb-buffer-pool-instances=4"
+      - "--innodb-redo-log-capacity=2G"
+      - "--innodb-flush-method=O_DIRECT"
+      - "--innodb-flush-log-at-trx-commit=1"
+      - "--innodb-io-capacity=2000"
+      - "--innodb-io-capacity-max=4000"
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+      - "--join-buffer-size=128M"
+      - "--sort-buffer-size=32M"
+      - "--tmp-table-size=512M"
+      - "--max-heap-table-size=512M"
+      - "--innodb-purge-threads=4"
+  postgres: # unused — empty key removes the service
+  mariadb: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase:
+    depends_on:
+      mysql:
+        condition: service_healthy
+
+flow: !include ['mysql.yml', 'flow']

--- a/benchmarks/chbenchmark/oracle.t1.yml
+++ b/benchmarks/chbenchmark/oracle.t1.yml
@@ -1,0 +1,61 @@
+---
+name: BenchBase Oracle Database Free CH-benCHmark benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  CH-benCHmark HTAP (TPC-C + TPC-H, BenchBase) on Oracle Database Free, tuning tier T1
+  (envelope-sized). SGA/PGA sized by a prepended ALTER SYSTEM step, as in tpcc/oracle.t1.yml.
+  CAVEAT: Oracle Free is licence-capped at ~2 GB RAM / 2 CPU threads, so the
+  T0->T1 delta is expected to be small; ALTERs are skipped under Automatic
+  Memory Management. VERIFY on first run; see TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  chbenchmark_requests:
+    unit: CH-benCHmark request
+    sci: true
+
+services:
+  # oracle service intentionally NOT listed -> kept as-is from compose.yml
+  # (Oracle exposes no command-flag config; T1 is applied at runtime by the
+  # prepended flow step below).
+  postgres: # unused — empty key removes the service
+  mariadb: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase: # load driver; wait for the database to be healthy first
+    depends_on:
+      oracle:
+        condition: service_healthy
+
+# T1 tuning runs as a prepended flow step (Oracle has no command-flag config).
+# Retries until the listener answers, continues past ORA errors, never fails the
+# run. Connects to the CDB root (service FREE) as SYSDBA.
+#
+# WHY THESE NUMBERS LOOK NOTHING LIKE THE OTHER ENGINES': Oracle Database Free is
+# licence-capped at ~2 GB of database RAM (SGA+PGA) and 2 CPU threads, so T1 is
+# sized against THAT cap, not the 8-GB cgroup every other engine gets:
+#     1300M (SGA) + 500M (PGA) = 1800M of the 2048M cap, ~250M headroom.
+# The procedure is identical (vendor rule applied to the effective memory limit);
+# only the effective limit differs. Oracle Free therefore cannot fill the shared
+# envelope, and its absolute J/op is not comparable on equal-hardware terms.
+# See TUNING.md: "How each T1 number is derived" + "Threats to validity".
+flow-prepend:
+  - name: Tune Oracle (T1 envelope-sized)
+    container: oracle_container
+    commands:
+      - type: console
+        note: APPLY T1 SGA/PGA SIZING (capped by Oracle Free 2 GB limit)
+        command: |
+          i=0; while [ $i -lt 30 ]; do
+            printf 'WHENEVER SQLERROR CONTINUE\nALTER SYSTEM SET sga_target=1300M SCOPE=BOTH;\nALTER SYSTEM SET pga_aggregate_target=500M SCOPE=BOTH;\nSHOW PARAMETER sga_target\nSHOW PARAMETER pga_aggregate_target\nEXIT\n' \
+              | sqlplus -s -L sys/oracle@//localhost:1521/FREE as sysdba && break
+            i=$((i+1)); sleep 3
+          done; true
+        shell: bash
+        log-stdout: true
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['oracle.yml', 'flow']

--- a/benchmarks/chbenchmark/oracle.t2.yml
+++ b/benchmarks/chbenchmark/oracle.t2.yml
@@ -1,0 +1,44 @@
+---
+name: BenchBase Oracle CH-benCHmark benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  CH-benCHmark (BenchBase, HTAP) on Oracle Database Free, tuning tier T2. T1
+  SGA/PGA sizing (prepended). Free's 2 GB / 2-thread cap bounds the analytical side
+  and there is no usable native advisor, so this is a CONFIG-PARITY (thin) T2 = T1.
+  See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  chbenchmark_requests:
+    unit: CH-benCHmark request
+    sci: true
+
+services:
+  postgres: # unused — empty key removes the service
+  mariadb: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase:
+    depends_on:
+      oracle:
+        condition: service_healthy
+
+flow-prepend:
+  - name: Tune Oracle (T1 envelope-sized)
+    container: oracle_container
+    commands:
+      - type: console
+        note: APPLY T1 SGA/PGA SIZING (capped by Oracle Free 2 GB limit)
+        command: |
+          i=0; while [ $i -lt 30 ]; do
+            printf 'WHENEVER SQLERROR CONTINUE\nALTER SYSTEM SET sga_target=1300M SCOPE=BOTH;\nALTER SYSTEM SET pga_aggregate_target=500M SCOPE=BOTH;\nSHOW PARAMETER sga_target\nSHOW PARAMETER pga_aggregate_target\nEXIT\n' \
+              | sqlplus -s -L sys/oracle@//localhost:1521/FREE as sysdba && break
+            i=$((i+1)); sleep 3
+          done; true
+        shell: bash
+        log-stdout: true
+
+flow: !include ['oracle.yml', 'flow']

--- a/benchmarks/chbenchmark/pg.t1.yml
+++ b/benchmarks/chbenchmark/pg.t1.yml
@@ -1,0 +1,71 @@
+---
+name: BenchBase PostgreSQL CH-benCHmark benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  CH-benCHmark HTAP (TPC-C + TPC-H, BenchBase) on PostgreSQL, tuning tier T1
+  (envelope-sized). Same hardware-sized engine config as tpcc/pg.t1.yml; durability left at
+  default. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  chbenchmark_requests:
+    unit: CH-benCHmark request
+    sci: true
+
+services:
+  # T1 tuning: passed as `postgres -c key=val` flags, which the official image's
+  # entrypoint forwards verbatim. Merged over compose.yml's postgres service, so
+  # image / cpus / mem_limit / env / healthcheck are inherited unchanged.
+  #
+  # Every literal below is recomputable from the 4-CPU / 8-GB envelope alone --
+  # see the derivation table in TUNING.md ("How each T1 number is derived").
+  # Postgres reads *through* the OS page cache, so its vendor rule is a 25%
+  # shared_buffers plus a 75% effective_cache_size planner hint -- NOT the ~62%
+  # single-cache sizing InnoDB / SQL Server use. Same rule, different arithmetic.
+  postgres:
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_buffers=2GB"            # 25% of the 8-GB cgroup (PostgreSQL standard)
+      - "-c"
+      - "effective_cache_size=6GB"      # planner hint: 75% (OS page cache, not an allocation)
+      - "-c"
+      - "maintenance_work_mem=512MB"
+      - "-c"
+      - "work_mem=16MB"                 # neutral; TPC-H raises this in T2
+      - "-c"
+      - "wal_buffers=16MB"
+      - "-c"
+      - "min_wal_size=1GB"
+      - "-c"
+      - "max_wal_size=4GB"
+      - "-c"
+      - "checkpoint_completion_target=0.9"
+      - "-c"
+      - "default_statistics_target=100"
+      - "-c"
+      - "random_page_cost=1.1"          # SSD-class storage
+      - "-c"
+      - "effective_io_concurrency=200"  # SSD-class storage
+      - "-c"
+      - "max_worker_processes=4"        # = cpus
+      - "-c"
+      - "max_parallel_workers=4"        # = cpus
+      - "-c"
+      - "max_parallel_workers_per_gather=2"
+      - "-c"
+      - "max_parallel_maintenance_workers=2"
+  mariadb: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase: # load driver; wait for the database to be healthy first
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['pg.yml', 'flow']

--- a/benchmarks/chbenchmark/pg.t2.yml
+++ b/benchmarks/chbenchmark/pg.t2.yml
@@ -1,0 +1,68 @@
+---
+name: BenchBase PostgreSQL CH-benCHmark benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  CH-benCHmark (BenchBase, HTAP) on PostgreSQL, tuning tier T2. T1 sizing + a
+  balance for the concurrent OLTP+OLAP mix: moderate work_mem and per-query
+  parallelism for the analytical queries, higher statistics target, and aggressive
+  autovacuum for the transactional churn. Config-only; shares the T0 flow.
+  (A columnar sub-tier isn't injectable here — no sqlcmd to add columnstore.)
+  See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  chbenchmark_requests:
+    unit: CH-benCHmark request
+    sci: true
+
+services:
+  postgres:
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_buffers=2GB"
+      - "-c"
+      - "effective_cache_size=6GB"
+      - "-c"
+      - "maintenance_work_mem=512MB"
+      - "-c"
+      - "work_mem=128MB"                        # T2: moderate (HTAP: OLAP + OLTP share RAM)
+      - "-c"
+      - "wal_buffers=16MB"
+      - "-c"
+      - "min_wal_size=1GB"
+      - "-c"
+      - "max_wal_size=4GB"
+      - "-c"
+      - "checkpoint_completion_target=0.9"
+      - "-c"
+      - "default_statistics_target=200"         # T2: better plans for the analytical queries
+      - "-c"
+      - "random_page_cost=1.1"
+      - "-c"
+      - "effective_io_concurrency=200"
+      - "-c"
+      - "max_worker_processes=4"
+      - "-c"
+      - "max_parallel_workers=4"
+      - "-c"
+      - "max_parallel_workers_per_gather=4"     # T2: parallelism for the OLAP side
+      - "-c"
+      - "max_parallel_maintenance_workers=2"
+      - "-c"
+      - "autovacuum_vacuum_scale_factor=0.05"   # T2: keep up with the OLTP side
+      - "-c"
+      - "autovacuum_vacuum_cost_limit=2000"
+  mariadb: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase:
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+flow: !include ['pg.yml', 'flow']

--- a/benchmarks/tpcc/db2.t1.yml
+++ b/benchmarks/tpcc/db2.t1.yml
@@ -1,0 +1,72 @@
+---
+name: HammerDB Db2 TPC-C benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-C on IBM Db2, tuning tier T1 (envelope-sized). Db2 self-tunes memory by
+  default (STMM); a prepended flow step ensures STMM is on and the memory areas
+  are AUTOMATIC (all applied online, never restarts, never fails the run). The
+  meaningful envelope lever for Db2 -- capping INSTANCE_MEMORY to the 8-GB cgroup
+  so STMM does not size against mis-detected host RAM -- needs an instance restart
+  and is left as a commented, opt-in block to enable after one VERIFY run.
+  Db2 Community Edition is capped at 16 GB / 4 cores, so the 8-GB/4-CPU envelope
+  fits within its limits (unlike Oracle Free). See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  sqlop:
+    unit: TPC-C SQL-op
+    sci: true
+
+services:
+  # db2 service intentionally NOT listed -> kept as-is from compose.yml
+  # (privileged + DBNAME=tpcc default; tuning applied by the prepended flow step).
+  postgres: # empty key will remove the unused service
+  mariadb: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  hammerdb: # Db2-enabled image (build/push with ./db/db2/build-image.sh); wait for Db2
+    image: ribalba/hammerdb-db2:latest
+    depends_on:
+      db2:
+        condition: service_healthy
+
+# T1 tuning runs as a prepended flow step (in the Db2 server container, as
+# db2inst1). Retries until the DB answers, echoes the applied config to stdout
+# for verification, never fails the run.
+#
+# WHY THERE ARE NO NUMBERS HERE: Db2's self-tuning memory manager (STMM) sizes
+# the buffer pool and sort heaps at runtime, so the vendor rule *is* "leave them
+# AUTOMATIC" -- there is no envelope literal to derive. Db2 Community is capped
+# at 16 GB / 4 cores, so the 8-GB / 4-CPU envelope fits (unlike Oracle Free).
+# The one lever that would pin STMM to the cgroup (INSTANCE_MEMORY) needs an
+# instance restart and is left opt-in below.
+# See TUNING.md: "How each T1 number is derived".
+flow-prepend:
+  - name: Tune Db2 (T1 envelope-sized)
+    container: db2_container
+    commands:
+      - type: console
+        note: ENSURE STMM SELF-TUNING + AUTOMATIC MEMORY (online)
+        command: |
+          su -l db2inst1 -c '
+            i=0; while [ $i -lt 40 ]; do db2 connect to tpcc >/dev/null 2>&1 && break; i=$((i+1)); sleep 3; done
+            db2 connect to tpcc
+            db2 update db cfg for tpcc using SELF_TUNING_MEM ON IMMEDIATE
+            db2 update db cfg for tpcc using DATABASE_MEMORY AUTOMATIC IMMEDIATE
+            db2 alter bufferpool IBMDEFAULTBP IMMEDIATE SIZE AUTOMATIC
+            db2 update db cfg for tpcc using SORTHEAP AUTOMATIC SHEAPTHRES_SHR AUTOMATIC IMMEDIATE
+            db2 get db cfg for tpcc | grep -iE "Self.Tuning|Database memory|Sort heap|Buffer"
+            db2 connect reset
+            # --- OPTIONAL (NEEDS VERIFY): cap instance memory to the 8 GB cgroup so
+            # --- STMM does not size against mis-detected host RAM. Needs a restart;
+            # --- the Catalog step that follows already retries the connection.
+            # db2 update dbm cfg using INSTANCE_MEMORY 1572864   # 6 GB in 4 KB pages
+            # db2stop force; db2start
+          ' || true
+        shell: bash
+        log-stdout: true
+
+# Same benchmark flow as the default (T0) scenario (Catalog -> Build -> Run -> Drop).
+flow: !include ['db2.yml', 'flow']

--- a/benchmarks/tpcc/db2.t2.yml
+++ b/benchmarks/tpcc/db2.t2.yml
@@ -1,0 +1,55 @@
+---
+name: HammerDB Db2 TPC-C benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-C on IBM Db2, tuning tier T2 (workload-aware, OLTP). T1 STMM self-tuning
+  (prepended). Db2 already self-tunes memory and TPC-C is fully indexed, so this is
+  a CONFIG-PARITY (thin) T2 = T1 for Db2 on TPC-C; the meaningful Db2 levers show
+  up on the analytical tiers (see db2.t2col for TPC-H BLU). See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  sqlop:
+    unit: TPC-C SQL-op
+    sci: true
+
+services:
+  # db2 kept as-is from compose.yml (DBNAME=tpcc default).
+  postgres: # empty key will remove the unused service
+  mariadb: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  hammerdb:
+    image: ribalba/hammerdb-db2:latest
+    depends_on:
+      db2:
+        condition: service_healthy
+
+flow-prepend:
+  - name: Tune Db2 (T1 envelope-sized)
+    container: db2_container
+    commands:
+      - type: console
+        note: ENSURE STMM SELF-TUNING + AUTOMATIC MEMORY (online)
+        command: |
+          su -l db2inst1 -c '
+            i=0; while [ $i -lt 40 ]; do db2 connect to tpcc >/dev/null 2>&1 && break; i=$((i+1)); sleep 3; done
+            db2 connect to tpcc
+            db2 update db cfg for tpcc using SELF_TUNING_MEM ON IMMEDIATE
+            db2 update db cfg for tpcc using DATABASE_MEMORY AUTOMATIC IMMEDIATE
+            db2 alter bufferpool IBMDEFAULTBP IMMEDIATE SIZE AUTOMATIC
+            db2 update db cfg for tpcc using SORTHEAP AUTOMATIC SHEAPTHRES_SHR AUTOMATIC IMMEDIATE
+            db2 get db cfg for tpcc | grep -iE "Self.Tuning|Database memory|Sort heap|Buffer"
+            db2 connect reset
+            # --- OPTIONAL (NEEDS VERIFY): cap instance memory to the 8 GB cgroup so
+            # --- STMM does not size against mis-detected host RAM. Needs a restart;
+            # --- the Catalog step that follows already retries the connection.
+            # db2 update dbm cfg using INSTANCE_MEMORY 1572864   # 6 GB in 4 KB pages
+            # db2stop force; db2start
+          ' || true
+        shell: bash
+        log-stdout: true
+
+flow: !include ['db2.yml', 'flow']

--- a/benchmarks/tpcc/maria.t1.yml
+++ b/benchmarks/tpcc/maria.t1.yml
@@ -1,0 +1,45 @@
+---
+name: HammerDB MariaDB TPC-C benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-C on MariaDB, tuning tier T1 (envelope-sized). Stock T0 plus InnoDB
+  rules-of-thumb for the fixed 4-CPU / 8-GB container. Durability kept at the
+  default (innodb_flush_log_at_trx_commit=1) so the T0->T1 delta is pure sizing.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  sqlop:
+    unit: TPC-C SQL-op
+    sci: true
+
+services:
+  # T1 tuning: flags appended to mariadbd by the image entrypoint. Merged over
+  # compose.yml. (buffer_pool_instances is omitted: a no-op on modern MariaDB.)
+  #
+  # Every literal below is recomputable from the 4-CPU / 8-GB envelope alone --
+  # see the derivation table in TUNING.md ("How each T1 number is derived").
+  # Same InnoDB rule as mysql.t1.yml: O_DIRECT makes the buffer pool the only
+  # cache, so it takes ~62% of the cgroup directly (vendor band: 50-75% of RAM).
+  mariadb:
+    command:
+      - "--innodb-buffer-pool-size=5G"           # 62.5% of the 8-GB cgroup
+      - "--innodb-log-file-size=2G"              # redo log sizing
+      - "--innodb-flush-method=O_DIRECT"         # avoid double-buffering w/ page cache
+      - "--innodb-flush-log-at-trx-commit=1"     # full durability (engine default, explicit)
+      - "--innodb-io-capacity=2000"              # SSD-class
+      - "--innodb-io-capacity-max=4000"          # SSD-class
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+  postgres: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb: # wait for MariaDB to finish starting up before benchmarking
+    depends_on:
+      mariadb:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['maria.yml', 'flow']

--- a/benchmarks/tpcc/maria.t2.yml
+++ b/benchmarks/tpcc/maria.t2.yml
@@ -1,0 +1,39 @@
+---
+name: HammerDB MariaDB TPC-C benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-C on MariaDB, tuning tier T2 (workload-aware, OLTP). T1 InnoDB sizing + OLTP
+  write-path tuning (more purge threads, full change buffering). Config-only;
+  shares the T0 flow. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  sqlop:
+    unit: TPC-C SQL-op
+    sci: true
+
+services:
+  mariadb:
+    command:
+      - "--innodb-buffer-pool-size=5G"
+      - "--innodb-log-file-size=2G"
+      - "--innodb-flush-method=O_DIRECT"
+      - "--innodb-flush-log-at-trx-commit=1"
+      - "--innodb-io-capacity=2000"
+      - "--innodb-io-capacity-max=4000"
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+      - "--innodb-purge-threads=4"            # T2: keep up with TPC-C purge load
+      - "--innodb-change-buffering=all"        # T2: buffer secondary-index writes
+  postgres: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb:
+    depends_on:
+      mariadb:
+        condition: service_healthy
+
+flow: !include ['maria.yml', 'flow']

--- a/benchmarks/tpcc/mssql.t1.yml
+++ b/benchmarks/tpcc/mssql.t1.yml
@@ -1,0 +1,41 @@
+---
+name: HammerDB MSSQL TPC-C benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-C on Microsoft SQL Server, tuning tier T1 (envelope-sized). SQL Server
+  manages its own buffer cache, so the dominant lever is "max server memory",
+  set via the image's MSSQL_MEMORY_LIMIT_MB env (5120 MB = ~62% of the 8-GB
+  container, leaving headroom for SQLOS/thread overhead to avoid cgroup OOM).
+  MAXDOP / cost-threshold are workload-specific and deferred to T2.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  sqlop:
+    unit: TPC-C SQL-op
+    sci: true
+
+services:
+  # T1 tuning: merged onto compose.yml's mssql environment (ACCEPT_EULA etc. kept).
+  #
+  # SQL Server manages its own buffer cache, so "max server memory" is the only
+  # envelope lever here; MAXDOP / cost-threshold are workload-specific -> T2.
+  # See the derivation table in TUNING.md ("How each T1 number is derived").
+  # Deliberate deviation from the vendor rule (leave 25-35% of RAM to the OS and
+  # SQLOS): we leave 37.5%, because under a hard cgroup limit an over-commit is a
+  # silent OOM-kill, not a swap slowdown.
+  mssql:
+    environment:
+      MSSQL_MEMORY_LIMIT_MB: "5120"   # max server memory; 62.5% of the 8-GB cgroup
+  postgres: # empty key will remove the unused service
+  mariadb: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb: # wait for SQL Server to finish starting up before benchmarking
+    depends_on:
+      mssql:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['mssql.yml', 'flow']

--- a/benchmarks/tpcc/mssql.t2.yml
+++ b/benchmarks/tpcc/mssql.t2.yml
@@ -1,0 +1,32 @@
+---
+name: HammerDB MSSQL TPC-C benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-C on SQL Server, tuning tier T2 (workload-aware, OLTP). For OLTP the only
+  injectable SQL Server lever is max server memory (already set in T1); finer OLTP
+  tuning (MAXDOP=1, cost threshold) needs sqlcmd, which the Linux server image
+  lacks. So this is intentionally a CONFIG-PARITY (thin) T2 = T1 for SQL Server on
+  TPC-C. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  sqlop:
+    unit: TPC-C SQL-op
+    sci: true
+
+services:
+  mssql:
+    environment:
+      MSSQL_MEMORY_LIMIT_MB: "5120"
+  postgres: # empty key will remove the unused service
+  mariadb: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb:
+    depends_on:
+      mssql:
+        condition: service_healthy
+
+flow: !include ['mssql.yml', 'flow']

--- a/benchmarks/tpcc/mysql.t1.yml
+++ b/benchmarks/tpcc/mysql.t1.yml
@@ -1,0 +1,47 @@
+---
+name: HammerDB MySQL TPC-C benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-C on MySQL, tuning tier T1 (envelope-sized). Stock T0 plus InnoDB
+  rules-of-thumb for the fixed 4-CPU / 8-GB container (buffer pool ~62% RAM,
+  O_DIRECT, SSD I/O capacity). Durability kept at the default
+  (innodb_flush_log_at_trx_commit=1) so the T0->T1 delta is pure resource sizing.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  sqlop:
+    unit: TPC-C SQL-op
+    sci: true
+
+services:
+  # T1 tuning: flags appended to mysqld by the official image entrypoint (it
+  # prepends `mysqld` when the command starts with `-`). Merged over compose.yml.
+  #
+  # Every literal below is recomputable from the 4-CPU / 8-GB envelope alone --
+  # see the derivation table in TUNING.md ("How each T1 number is derived").
+  # InnoDB with O_DIRECT owns the only page cache, so the buffer pool takes ~62%
+  # of the cgroup directly (vendor band: 50-75% of RAM).
+  mysql:
+    command:
+      - "--innodb-buffer-pool-size=5G"           # 62.5% of the 8-GB cgroup
+      - "--innodb-buffer-pool-instances=4"       # 5G / 4 = 1.25 GB each (>= 1 GB rule)
+      - "--innodb-redo-log-capacity=2G"          # MySQL 8.0.30+/9.x redo sizing
+      - "--innodb-flush-method=O_DIRECT"         # avoid double-buffering w/ page cache
+      - "--innodb-flush-log-at-trx-commit=1"     # full durability (engine default, explicit)
+      - "--innodb-io-capacity=2000"              # SSD-class
+      - "--innodb-io-capacity-max=4000"          # SSD-class
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+  postgres: # empty key will remove the unused service
+  mariadb: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb: # wait for MySQL to finish starting up before benchmarking
+    depends_on:
+      mysql:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['mysql.yml', 'flow']

--- a/benchmarks/tpcc/mysql.t2.yml
+++ b/benchmarks/tpcc/mysql.t2.yml
@@ -1,0 +1,41 @@
+---
+name: HammerDB MySQL TPC-C benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-C on MySQL, tuning tier T2 (workload-aware, OLTP). T1 InnoDB sizing + OLTP
+  write-path tuning (more purge threads, full change buffering, adaptive hash
+  index). Config-only; shares the T0 flow. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  sqlop:
+    unit: TPC-C SQL-op
+    sci: true
+
+services:
+  mysql:
+    command:
+      - "--innodb-buffer-pool-size=5G"
+      - "--innodb-buffer-pool-instances=4"
+      - "--innodb-redo-log-capacity=2G"
+      - "--innodb-flush-method=O_DIRECT"
+      - "--innodb-flush-log-at-trx-commit=1"
+      - "--innodb-io-capacity=2000"
+      - "--innodb-io-capacity-max=4000"
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+      - "--innodb-purge-threads=4"            # T2: keep up with TPC-C purge load
+      - "--innodb-change-buffering=all"        # T2: buffer secondary-index writes
+      - "--innodb-adaptive-hash-index=ON"
+  postgres: # empty key will remove the unused service
+  mariadb: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb:
+    depends_on:
+      mysql:
+        condition: service_healthy
+
+flow: !include ['mysql.yml', 'flow']

--- a/benchmarks/tpcc/oracle.t1.yml
+++ b/benchmarks/tpcc/oracle.t1.yml
@@ -1,0 +1,68 @@
+---
+name: HammerDB Oracle TPC-C benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-C on Oracle Database Free, tuning tier T1 (envelope-sized). Oracle has no
+  command-flag config, so a prepended flow step runs ALTER SYSTEM in
+  oracle_container before the workload.
+  CAVEAT: Oracle Database Free is licence-capped at ~2 GB RAM / 2 CPU threads, so
+  it CANNOT use the 8-GB / 4-CPU envelope; T1 sizes the SGA/PGA up to that cap, so
+  the T0->T1 delta is expected to be small. If the instance uses Automatic Memory
+  Management (memory_target>0) the SGA/PGA ALTERs are skipped (need a restart) --
+  check this step's stdout in the run log to confirm what was applied. VERIFY on
+  first run.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  sqlop:
+    unit: TPC-C SQL-op
+    sci: true
+
+services:
+  # oracle service intentionally NOT listed -> kept as-is from compose.yml
+  # (Oracle exposes no command-flag config; T1 is applied at runtime by the
+  # prepended flow step below).
+  postgres: # empty key will remove the unused service
+  mariadb: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb: # wait for Oracle to finish starting up before benchmarking
+    depends_on:
+      oracle:
+        condition: service_healthy
+    # Oracle Instant Client ships in the hammerdb image but its dir is not on the
+    # loader path; needed so libclntsh.so finds libnnz21.so / libclntshcore.so.
+    environment:
+      LD_LIBRARY_PATH: /home/instantclient_21_18
+
+# T1 tuning runs as a prepended flow step (Oracle has no command-flag config).
+# Retries until the listener answers, continues past ORA errors, never fails the
+# run. Connects to the CDB root (service FREE) as SYSDBA.
+#
+# WHY THESE NUMBERS LOOK NOTHING LIKE THE OTHER ENGINES': Oracle Database Free is
+# licence-capped at ~2 GB of database RAM (SGA+PGA) and 2 CPU threads, so T1 is
+# sized against THAT cap, not the 8-GB cgroup every other engine gets:
+#     1300M (SGA) + 500M (PGA) = 1800M of the 2048M cap, ~250M headroom.
+# The procedure is identical (vendor rule applied to the effective memory limit);
+# only the effective limit differs. Oracle Free therefore cannot fill the shared
+# envelope, and its absolute J/op is not comparable on equal-hardware terms.
+# See TUNING.md: "How each T1 number is derived" + "Threats to validity".
+flow-prepend:
+  - name: Tune Oracle (T1 envelope-sized)
+    container: oracle_container
+    commands:
+      - type: console
+        note: APPLY T1 SGA/PGA SIZING (capped by Oracle Free 2 GB limit)
+        command: |
+          i=0; while [ $i -lt 30 ]; do
+            printf 'WHENEVER SQLERROR CONTINUE\nALTER SYSTEM SET sga_target=1300M SCOPE=BOTH;\nALTER SYSTEM SET pga_aggregate_target=500M SCOPE=BOTH;\nSHOW PARAMETER sga_target\nSHOW PARAMETER pga_aggregate_target\nEXIT\n' \
+              | sqlplus -s -L sys/oracle@//localhost:1521/FREE as sysdba && break
+            i=$((i+1)); sleep 3
+          done; true
+        shell: bash
+        log-stdout: true
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['oracle.yml', 'flow']

--- a/benchmarks/tpcc/oracle.t2.yml
+++ b/benchmarks/tpcc/oracle.t2.yml
@@ -1,0 +1,45 @@
+---
+name: HammerDB Oracle TPC-C benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-C on Oracle Database Free, tuning tier T2 (workload-aware, OLTP). T1 SGA/PGA
+  sizing (prepended). Oracle Free's 2 GB / 2-thread cap leaves little OLTP headroom
+  beyond T1 and there is no usable native advisor, so this is a CONFIG-PARITY
+  (thin) T2 = T1 for Oracle on TPC-C. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  sqlop:
+    unit: TPC-C SQL-op
+    sci: true
+
+services:
+  postgres: # empty key will remove the unused service
+  mariadb: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb:
+    depends_on:
+      oracle:
+        condition: service_healthy
+    environment:
+      LD_LIBRARY_PATH: /home/instantclient_21_18
+
+flow-prepend:
+  - name: Tune Oracle (T1 envelope-sized)
+    container: oracle_container
+    commands:
+      - type: console
+        note: APPLY T1 SGA/PGA SIZING (capped by Oracle Free 2 GB limit)
+        command: |
+          i=0; while [ $i -lt 30 ]; do
+            printf 'WHENEVER SQLERROR CONTINUE\nALTER SYSTEM SET sga_target=1300M SCOPE=BOTH;\nALTER SYSTEM SET pga_aggregate_target=500M SCOPE=BOTH;\nSHOW PARAMETER sga_target\nSHOW PARAMETER pga_aggregate_target\nEXIT\n' \
+              | sqlplus -s -L sys/oracle@//localhost:1521/FREE as sysdba && break
+            i=$((i+1)); sleep 3
+          done; true
+        shell: bash
+        log-stdout: true
+
+flow: !include ['oracle.yml', 'flow']

--- a/benchmarks/tpcc/pg.t1.yml
+++ b/benchmarks/tpcc/pg.t1.yml
@@ -1,0 +1,73 @@
+---
+name: HammerDB Postgres TPC-C benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-C on PostgreSQL, tuning tier T1 (envelope-sized). Stock T0 config plus
+  PostgreSQL's own rules-of-thumb sized to the fixed 4-CPU / 8-GB container
+  (shared_buffers=25% RAM, effective_cache_size=75% RAM, SSD I/O costs, parallel
+  workers = core count). Durability is left at the default (synchronous_commit=on,
+  fsync=on) so the comparison against T0 isolates resource sizing, not safety.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  sqlop:
+    unit: TPC-C SQL-op
+    sci: true
+
+services:
+  # T1 tuning: passed as `postgres -c key=val` flags, which the official image's
+  # entrypoint forwards verbatim. Merged over compose.yml's postgres service, so
+  # image / cpus / mem_limit / env / healthcheck are inherited unchanged.
+  #
+  # Every literal below is recomputable from the 4-CPU / 8-GB envelope alone --
+  # see the derivation table in TUNING.md ("How each T1 number is derived").
+  # Postgres reads *through* the OS page cache, so its vendor rule is a 25%
+  # shared_buffers plus a 75% effective_cache_size planner hint -- NOT the ~62%
+  # single-cache sizing InnoDB / SQL Server use. Same rule, different arithmetic.
+  postgres:
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_buffers=2GB"            # 25% of the 8-GB cgroup (PostgreSQL standard)
+      - "-c"
+      - "effective_cache_size=6GB"      # planner hint: 75% (OS page cache, not an allocation)
+      - "-c"
+      - "maintenance_work_mem=512MB"
+      - "-c"
+      - "work_mem=16MB"                 # neutral; TPC-H raises this in T2
+      - "-c"
+      - "wal_buffers=16MB"
+      - "-c"
+      - "min_wal_size=1GB"
+      - "-c"
+      - "max_wal_size=4GB"
+      - "-c"
+      - "checkpoint_completion_target=0.9"
+      - "-c"
+      - "default_statistics_target=100"
+      - "-c"
+      - "random_page_cost=1.1"          # SSD-class storage
+      - "-c"
+      - "effective_io_concurrency=200"  # SSD-class storage
+      - "-c"
+      - "max_worker_processes=4"        # = cpus
+      - "-c"
+      - "max_parallel_workers=4"        # = cpus
+      - "-c"
+      - "max_parallel_workers_per_gather=2"
+      - "-c"
+      - "max_parallel_maintenance_workers=2"
+  mariadb: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb: # wait for Postgres to finish starting up before benchmarking
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario: tiers differ only in engine
+# config, never in the workload. Single source of truth lives in pg.yml.
+flow: !include ['pg.yml', 'flow']

--- a/benchmarks/tpcc/pg.t2.yml
+++ b/benchmarks/tpcc/pg.t2.yml
@@ -1,0 +1,69 @@
+---
+name: HammerDB Postgres TPC-C benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-C on PostgreSQL, tuning tier T2 (workload-aware, OLTP). T1 envelope sizing +
+  OLTP-favourable config: more aggressive autovacuum to keep up with TPC-C's heavy
+  update/churn (vs T1 defaults). TPC-C is fully indexed by HammerDB and isn't
+  parallelised, so T2 here is config-only and shares the T0 flow. Durability left
+  at default. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  sqlop:
+    unit: TPC-C SQL-op
+    sci: true
+
+services:
+  postgres:
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_buffers=2GB"
+      - "-c"
+      - "effective_cache_size=6GB"
+      - "-c"
+      - "maintenance_work_mem=512MB"
+      - "-c"
+      - "work_mem=16MB"
+      - "-c"
+      - "wal_buffers=16MB"
+      - "-c"
+      - "min_wal_size=1GB"
+      - "-c"
+      - "max_wal_size=4GB"
+      - "-c"
+      - "checkpoint_completion_target=0.9"
+      - "-c"
+      - "default_statistics_target=100"
+      - "-c"
+      - "random_page_cost=1.1"
+      - "-c"
+      - "effective_io_concurrency=200"
+      - "-c"
+      - "max_worker_processes=4"
+      - "-c"
+      - "max_parallel_workers=4"
+      - "-c"
+      - "max_parallel_workers_per_gather=2"
+      - "-c"
+      - "max_parallel_maintenance_workers=2"
+      - "-c"
+      - "autovacuum_vacuum_scale_factor=0.05"   # T2: keep up with TPC-C churn
+      - "-c"
+      - "autovacuum_vacuum_cost_limit=2000"      # T2: faster autovacuum
+      - "-c"
+      - "autovacuum_naptime=10s"                 # T2: vacuum more often
+  mariadb: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb:
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+# OLTP T2 is config-only (no schema/parallelism change), so share the T0 flow.
+flow: !include ['pg.yml', 'flow']

--- a/benchmarks/tpch/db2.t1.yml
+++ b/benchmarks/tpch/db2.t1.yml
@@ -1,0 +1,71 @@
+---
+name: HammerDB Db2 TPC-H benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-H on IBM Db2, tuning tier T1 (envelope-sized). Same Db2 self-tuning (STMM)
+  approach as tpcc/db2.t1.yml, applied to the tpch database. The optional
+  INSTANCE_MEMORY cap (needs a restart) is left commented for opt-in after a
+  VERIFY run. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  tpch_queries:
+    unit: TPC-H query
+    sci: true
+
+services:
+  db2: # this benchmark needs the tpch database instead of the default tpcc
+    environment:
+      LICENSE: accept
+      DB2INST1_PASSWORD: ibmdb2
+      DBNAME: tpch
+  postgres: # empty key will remove the unused service
+  mariadb: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  hammerdb: # Db2-enabled image (build/push with ./db/db2/build-image.sh); wait for Db2
+    image: ribalba/hammerdb-db2:latest
+    depends_on:
+      db2:
+        condition: service_healthy
+
+# T1 tuning runs as a prepended flow step (in the Db2 server container, as
+# db2inst1). Retries until the DB answers, echoes the applied config to stdout
+# for verification, never fails the run.
+#
+# WHY THERE ARE NO NUMBERS HERE: Db2's self-tuning memory manager (STMM) sizes
+# the buffer pool and sort heaps at runtime, so the vendor rule *is* "leave them
+# AUTOMATIC" -- there is no envelope literal to derive. Db2 Community is capped
+# at 16 GB / 4 cores, so the 8-GB / 4-CPU envelope fits (unlike Oracle Free).
+# The one lever that would pin STMM to the cgroup (INSTANCE_MEMORY) needs an
+# instance restart and is left opt-in below.
+# See TUNING.md: "How each T1 number is derived".
+flow-prepend:
+  - name: Tune Db2 (T1 envelope-sized)
+    container: db2_container
+    commands:
+      - type: console
+        note: ENSURE STMM SELF-TUNING + AUTOMATIC MEMORY (online)
+        command: |
+          su -l db2inst1 -c '
+            i=0; while [ $i -lt 40 ]; do db2 connect to tpch >/dev/null 2>&1 && break; i=$((i+1)); sleep 3; done
+            db2 connect to tpch
+            db2 update db cfg for tpch using SELF_TUNING_MEM ON IMMEDIATE
+            db2 update db cfg for tpch using DATABASE_MEMORY AUTOMATIC IMMEDIATE
+            db2 alter bufferpool IBMDEFAULTBP IMMEDIATE SIZE AUTOMATIC
+            db2 update db cfg for tpch using SORTHEAP AUTOMATIC SHEAPTHRES_SHR AUTOMATIC IMMEDIATE
+            db2 get db cfg for tpch | grep -iE "Self.Tuning|Database memory|Sort heap|Buffer"
+            db2 connect reset
+            # --- OPTIONAL (NEEDS VERIFY): cap instance memory to the 8 GB cgroup so
+            # --- STMM does not size against mis-detected host RAM. Needs a restart;
+            # --- the Catalog step that follows already retries the connection.
+            # db2 update dbm cfg using INSTANCE_MEMORY 1572864   # 6 GB in 4 KB pages
+            # db2stop force; db2start
+          ' || true
+        shell: bash
+        log-stdout: true
+
+# Same benchmark flow as the default (T0) scenario (Catalog -> Build -> Run -> Drop).
+flow: !include ['db2.yml', 'flow']

--- a/benchmarks/tpch/db2.t2.yml
+++ b/benchmarks/tpch/db2.t2.yml
@@ -1,0 +1,131 @@
+---
+name: HammerDB Db2 TPC-H benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-H on IBM Db2, tuning tier T2 (workload-aware, common/row-store). T1 STMM
+  (prepended) + a post-load optimize step that enables intra-partition
+  parallelism (INTRA_PARALLEL / MAX_QUERYDEGREE / DFT_DEGREE), adds curated
+  analytical indexes, and refreshes statistics (RUNSTATS via reorgchk). Db2's
+  native Design Advisor (db2advis) could supplement this; see TUNING.md.
+  CAVEAT: INTRA_PARALLEL fully engages only after an instance restart — the BLU
+  columnar variant (db2.t2col.yml) is the stronger Db2 analytical design. VERIFY
+  the optimize step's stdout on first run.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  tpch_queries:
+    unit: TPC-H query
+    sci: true
+
+services:
+  db2:
+    environment:
+      LICENSE: accept
+      DB2INST1_PASSWORD: ibmdb2
+      DBNAME: tpch
+  postgres: # empty key will remove the unused service
+  mariadb: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  hammerdb:
+    image: ribalba/hammerdb-db2:latest
+    depends_on:
+      db2:
+        condition: service_healthy
+
+flow-prepend:
+  - name: Tune Db2 (T1 envelope-sized)
+    container: db2_container
+    commands:
+      - type: console
+        note: ENSURE STMM SELF-TUNING + AUTOMATIC MEMORY (online)
+        command: |
+          su -l db2inst1 -c '
+            i=0; while [ $i -lt 40 ]; do db2 connect to tpch >/dev/null 2>&1 && break; i=$((i+1)); sleep 3; done
+            db2 connect to tpch
+            db2 update db cfg for tpch using SELF_TUNING_MEM ON IMMEDIATE
+            db2 update db cfg for tpch using DATABASE_MEMORY AUTOMATIC IMMEDIATE
+            db2 connect reset
+          ' || true
+        shell: bash
+        log-stdout: true
+
+flow:
+  # Db2 is excluded from the paper (kept only for benchmarking), so enlarging its
+  # undersized default transaction log here is fine. Without this the bulk load fails
+  # with SQL0964C (log full).
+  - name: Size Db2 transaction log
+    container: db2_container
+    commands:
+      - type: console
+        note: ENLARGE TRANSACTION LOG before the bulk load (avoids SQL0964C "log full")
+        command: |
+          su -l db2inst1 -c '
+            i=0; while [ $i -lt 40 ]; do db2 connect to tpch >/dev/null 2>&1 && break; i=$((i+1)); sleep 3; done
+            db2 connect reset
+            db2 update db cfg for tpch using LOGFILSIZ 8192 LOGPRIMARY 16 LOGSECOND 48
+            db2 force application all
+            db2 deactivate db tpch
+            db2 get db cfg for tpch | grep -iE "Log file size|primary log|secondary log"
+          ' || true
+        shell: bash
+        log-stdout: true
+  - name: Catalog Db2
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: CATALOG REMOTE DB2
+        command: chmod -R u+rwX /database/config/db2inst1/sqllib 2>/dev/null; rm -f /database/config/db2inst1/sqllib/db2nodes.cfg; echo "0 $(hostname) 0" > /database/config/db2inst1/sqllib/db2nodes.cfg && . /database/config/db2inst1/sqllib/db2profile && { db2 uncatalog database tpch; db2 uncatalog node db2node; true; } && db2 catalog tcpip node db2node remote db2_container server 50000 && db2 catalog database tpch at node db2node && db2 terminate && (i=0; while [ $i -lt 30 ]; do db2 connect to tpch >/dev/null 2>&1 && db2 connect reset >/dev/null 2>&1 && break; i=$((i+1)); sleep 3; done)
+        shell: sh
+        log-stdout: true
+  - name: Build Schema
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB BUILD
+        command: . /database/config/db2inst1/sqllib/db2profile && cd /home/HammerDB-5.0 && ./hammerdbcli auto /tmp/repo/db/db2/tpch/db2_tproch_buildschema.tcl | tee /dev/stderr | awk '/query [0-9]+ completed in/{q++} END{if(q>0){"date +%s"|getline ts; printf("%s000000 tpch_queries=%d\n", ts, q)}}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Optimize schema (T2)
+    container: db2_container
+    commands:
+      - type: console
+        note: T2 PARALLELISM + CURATED INDEXES + RUNSTATS (non-fatal; VERIFY)
+        command: |
+          su -l db2inst1 -c '
+            db2 update dbm cfg using INTRA_PARALLEL YES
+            db2 update dbm cfg using MAX_QUERYDEGREE 4
+            db2 connect to tpch
+            db2 update db cfg for tpch using DFT_DEGREE 4
+            db2 "create index t2_l_shipdate on lineitem(l_shipdate)"
+            db2 "create index t2_l_partkey on lineitem(l_partkey)"
+            db2 "create index t2_l_suppkey on lineitem(l_suppkey)"
+            db2 "create index t2_o_orderdate on orders(o_orderdate)"
+            db2 "create index t2_o_custkey on orders(o_custkey)"
+            db2 "create index t2_ps_suppkey on partsupp(ps_suppkey)"
+            db2 reorgchk update statistics on table all
+            db2 connect reset
+          ' || true
+        shell: bash
+        log-stdout: true
+  - name: Run Queries
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB QUERIES
+        command: . /database/config/db2inst1/sqllib/db2profile && cd /home/HammerDB-5.0 && ./hammerdbcli auto /tmp/repo/db/db2/tpch/db2_tproch_run.tcl | tee /dev/stderr | awk 'END{"date +%s"|getline ts; printf("%s000000 tpch_queries=22\n", ts)}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Drop Schema
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB DROP
+        command: . /database/config/db2inst1/sqllib/db2profile && cd /home/HammerDB-5.0 && ./hammerdbcli auto /tmp/repo/db/db2/tpch/db2_tproch_deleteschema.tcl | tee /dev/stderr | awk '/query [0-9]+ completed in/{q++} END{if(q>0){"date +%s"|getline ts; printf("%s000000 tpch_queries=%d\n", ts, q)}}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true

--- a/benchmarks/tpch/db2.t2col.yml
+++ b/benchmarks/tpch/db2.t2col.yml
@@ -1,0 +1,123 @@
+---
+name: HammerDB Db2 TPC-H benchmark (T2+ columnar / BLU)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-H on IBM Db2, tuning sub-tier T2+ (COLUMNAR / BLU). The schema is built as
+  column-organized tables (db2_tproch_buildschema.t2col.tcl, organizeby COLUMN) —
+  Db2's strongest analytical design. A prepended step puts the instance in analytic
+  mode (DB2_WORKLOAD=ANALYTICS, which enables intra-parallelism + BLU defaults) and
+  restarts it before the build.
+  CAVEAT: BLU enablement (DB2_WORKLOAD + restart + column-organized build) could
+  not be verified offline — VERIFY on first run (check the Tune/Build step stdout).
+  This is the columnar counterpart to db2.t2.yml.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  tpch_queries:
+    unit: TPC-H query
+    sci: true
+
+services:
+  db2:
+    environment:
+      LICENSE: accept
+      DB2INST1_PASSWORD: ibmdb2
+      DBNAME: tpch
+  postgres: # empty key will remove the unused service
+  mariadb: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  hammerdb:
+    image: ribalba/hammerdb-db2:latest
+    depends_on:
+      db2:
+        condition: service_healthy
+
+flow-prepend:
+  - name: Enable Db2 BLU (T2 columnar)
+    container: db2_container
+    commands:
+      - type: console
+        note: DB2_WORKLOAD=ANALYTICS + instance restart + STMM (needs restart; VERIFY)
+        command: |
+          su -l db2inst1 -c '
+            db2set DB2_WORKLOAD=ANALYTICS
+            db2stop force; db2start
+            i=0; while [ $i -lt 40 ]; do db2 connect to tpch >/dev/null 2>&1 && break; i=$((i+1)); sleep 3; done
+            db2 connect to tpch
+            db2 update db cfg for tpch using SELF_TUNING_MEM ON DATABASE_MEMORY AUTOMATIC IMMEDIATE
+            db2 connect reset
+          ' || true
+        shell: bash
+        log-stdout: true
+
+flow:
+  # Db2 is excluded from the paper (kept only for benchmarking), so enlarging its
+  # undersized default transaction log here is fine. Without this the bulk load fails
+  # with SQL0964C (log full).
+  - name: Size Db2 transaction log
+    container: db2_container
+    commands:
+      - type: console
+        note: ENLARGE TRANSACTION LOG before the bulk load (avoids SQL0964C "log full")
+        command: |
+          su -l db2inst1 -c '
+            i=0; while [ $i -lt 40 ]; do db2 connect to tpch >/dev/null 2>&1 && break; i=$((i+1)); sleep 3; done
+            db2 connect reset
+            db2 update db cfg for tpch using LOGFILSIZ 8192 LOGPRIMARY 16 LOGSECOND 48
+            db2 force application all
+            db2 deactivate db tpch
+            db2 get db cfg for tpch | grep -iE "Log file size|primary log|secondary log"
+          ' || true
+        shell: bash
+        log-stdout: true
+  - name: Catalog Db2
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: CATALOG REMOTE DB2
+        command: chmod -R u+rwX /database/config/db2inst1/sqllib 2>/dev/null; rm -f /database/config/db2inst1/sqllib/db2nodes.cfg; echo "0 $(hostname) 0" > /database/config/db2inst1/sqllib/db2nodes.cfg && . /database/config/db2inst1/sqllib/db2profile && { db2 uncatalog database tpch; db2 uncatalog node db2node; true; } && db2 catalog tcpip node db2node remote db2_container server 50000 && db2 catalog database tpch at node db2node && db2 terminate && (i=0; while [ $i -lt 30 ]; do db2 connect to tpch >/dev/null 2>&1 && db2 connect reset >/dev/null 2>&1 && break; i=$((i+1)); sleep 3; done)
+        shell: sh
+        log-stdout: true
+  - name: Build Schema (columnar)
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB BUILD (BLU column-organized)
+        command: . /database/config/db2inst1/sqllib/db2profile && cd /home/HammerDB-5.0 && ./hammerdbcli auto /tmp/repo/db/db2/tpch/db2_tproch_buildschema.t2col.tcl | tee /dev/stderr | awk '/query [0-9]+ completed in/{q++} END{if(q>0){"date +%s"|getline ts; printf("%s000000 tpch_queries=%d\n", ts, q)}}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Optimize schema (T2 columnar)
+    container: db2_container
+    commands:
+      - type: console
+        note: RUNSTATS (BLU needs no secondary indexes; non-fatal)
+        command: |
+          su -l db2inst1 -c '
+            db2 connect to tpch
+            db2 reorgchk update statistics on table all
+            db2 connect reset
+          ' || true
+        shell: bash
+        log-stdout: true
+  - name: Run Queries
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB QUERIES
+        command: . /database/config/db2inst1/sqllib/db2profile && cd /home/HammerDB-5.0 && ./hammerdbcli auto /tmp/repo/db/db2/tpch/db2_tproch_run.tcl | tee /dev/stderr | awk 'END{"date +%s"|getline ts; printf("%s000000 tpch_queries=22\n", ts)}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Drop Schema
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB DROP
+        command: . /database/config/db2inst1/sqllib/db2profile && cd /home/HammerDB-5.0 && ./hammerdbcli auto /tmp/repo/db/db2/tpch/db2_tproch_deleteschema.tcl | tee /dev/stderr | awk '/query [0-9]+ completed in/{q++} END{if(q>0){"date +%s"|getline ts; printf("%s000000 tpch_queries=%d\n", ts, q)}}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true

--- a/benchmarks/tpch/maria.t1.yml
+++ b/benchmarks/tpch/maria.t1.yml
@@ -1,0 +1,44 @@
+---
+name: HammerDB MariaDB TPC-H benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-H on MariaDB, tuning tier T1 (envelope-sized). Identical engine config to
+  tpcc/maria.t1.yml (hardware-sized, workload-agnostic). See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  tpch_queries:
+    unit: TPC-H query
+    sci: true
+
+services:
+  # T1 tuning: flags appended to mariadbd by the image entrypoint. Merged over
+  # compose.yml. (buffer_pool_instances is omitted: a no-op on modern MariaDB.)
+  #
+  # Every literal below is recomputable from the 4-CPU / 8-GB envelope alone --
+  # see the derivation table in TUNING.md ("How each T1 number is derived").
+  # Same InnoDB rule as mysql.t1.yml: O_DIRECT makes the buffer pool the only
+  # cache, so it takes ~62% of the cgroup directly (vendor band: 50-75% of RAM).
+  mariadb:
+    command:
+      - "--innodb-buffer-pool-size=5G"           # 62.5% of the 8-GB cgroup
+      - "--innodb-log-file-size=2G"              # redo log sizing
+      - "--innodb-flush-method=O_DIRECT"         # avoid double-buffering w/ page cache
+      - "--innodb-flush-log-at-trx-commit=1"     # full durability (engine default, explicit)
+      - "--innodb-io-capacity=2000"              # SSD-class
+      - "--innodb-io-capacity-max=4000"          # SSD-class
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+  postgres: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb: # wait for MariaDB to finish starting up before benchmarking
+    depends_on:
+      mariadb:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['maria.yml', 'flow']

--- a/benchmarks/tpch/maria.t2.yml
+++ b/benchmarks/tpch/maria.t2.yml
@@ -1,0 +1,87 @@
+---
+name: HammerDB MariaDB TPC-H benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-H on MariaDB, tuning tier T2 (workload-aware). T1 InnoDB sizing + OLAP
+  session buffers (MariaDB has no parallel query). Post-load optimize step adds
+  curated analytical indexes (IF NOT EXISTS) and refreshes statistics. No columnar
+  sub-tier. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  tpch_queries:
+    unit: TPC-H query
+    sci: true
+
+services:
+  mariadb:
+    command:
+      - "--innodb-buffer-pool-size=5G"
+      - "--innodb-log-file-size=2G"
+      - "--innodb-flush-method=O_DIRECT"
+      - "--innodb-flush-log-at-trx-commit=1"
+      - "--innodb-io-capacity=2000"
+      - "--innodb-io-capacity-max=4000"
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+      - "--join-buffer-size=128M"            # T2: large hash joins for OLAP
+      - "--sort-buffer-size=32M"
+      - "--read-rnd-buffer-size=16M"
+      - "--tmp-table-size=512M"
+      - "--max-heap-table-size=512M"
+  postgres: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb:
+    depends_on:
+      mariadb:
+        condition: service_healthy
+
+flow:
+  - name: Build Schema
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB BUILD
+        command: ./hammerdbcli auto /tmp/repo/db/maria/tpch/maria_tproch_buildschema.tcl | tee /dev/stderr | awk '/query [0-9]+ completed in/{q++} END{if(q>0){"date +%s"|getline ts; printf("%s000000 tpch_queries=%d\n", ts, q)}}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Optimize schema (T2)
+    container: mariadb_container
+    commands:
+      - type: console
+        note: T2 CURATED INDEXES + ANALYZE (non-fatal; VERIFY names)
+        command: |
+          mariadb -uroot -pmaria tpch -e "
+            CREATE INDEX IF NOT EXISTS t2_l_shipdate ON lineitem (l_shipdate);
+            CREATE INDEX IF NOT EXISTS t2_l_partkey  ON lineitem (l_partkey);
+            CREATE INDEX IF NOT EXISTS t2_l_suppkey  ON lineitem (l_suppkey);
+            CREATE INDEX IF NOT EXISTS t2_o_orderdate ON orders (o_orderdate);
+            CREATE INDEX IF NOT EXISTS t2_o_custkey   ON orders (o_custkey);
+            CREATE INDEX IF NOT EXISTS t2_ps_suppkey  ON partsupp (ps_suppkey);
+          " || true
+          mariadb-check -uroot -pmaria --analyze --databases tpch || true
+        shell: bash
+        log-stdout: true
+  - name: Run Queries
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB QUERIES
+        command: ./hammerdbcli auto /tmp/repo/db/maria/tpch/maria_tproch_run.tcl | tee /dev/stderr | awk 'END{"date +%s"|getline ts; printf("%s000000 tpch_queries=22\n", ts)}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Drop Schema
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB DROP
+        command: ./hammerdbcli auto /tmp/repo/db/maria/tpch/maria_tproch_deleteschema.tcl | tee /dev/stderr | awk '/query [0-9]+ completed in/{q++} END{if(q>0){"date +%s"|getline ts; printf("%s000000 tpch_queries=%d\n", ts, q)}}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true

--- a/benchmarks/tpch/mssql.t1.yml
+++ b/benchmarks/tpch/mssql.t1.yml
@@ -1,0 +1,38 @@
+---
+name: HammerDB MSSQL TPC-H benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-H on Microsoft SQL Server, tuning tier T1 (envelope-sized). Same engine
+  config as tpcc/mssql.t1.yml (hardware-sized, workload-agnostic). See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  tpch_queries:
+    unit: TPC-H query
+    sci: true
+
+services:
+  # T1 tuning: merged onto compose.yml's mssql environment (ACCEPT_EULA etc. kept).
+  #
+  # SQL Server manages its own buffer cache, so "max server memory" is the only
+  # envelope lever here; MAXDOP / cost-threshold are workload-specific -> T2.
+  # See the derivation table in TUNING.md ("How each T1 number is derived").
+  # Deliberate deviation from the vendor rule (leave 25-35% of RAM to the OS and
+  # SQLOS): we leave 37.5%, because under a hard cgroup limit an over-commit is a
+  # silent OOM-kill, not a swap slowdown.
+  mssql:
+    environment:
+      MSSQL_MEMORY_LIMIT_MB: "5120"   # max server memory; 62.5% of the 8-GB cgroup
+  postgres: # empty key will remove the unused service
+  mariadb: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb: # wait for SQL Server to finish starting up before benchmarking
+    depends_on:
+      mssql:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['mssql.yml', 'flow']

--- a/benchmarks/tpch/mssql.t2.yml
+++ b/benchmarks/tpch/mssql.t2.yml
@@ -1,0 +1,62 @@
+---
+name: HammerDB MSSQL TPC-H benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-H on Microsoft SQL Server, tuning tier T2 (workload-aware, common/row-store
+  design). T1 memory sizing + analytical parallelism: MAXDOP raised to 4 in the
+  build (mssql_tproch_buildschema.t2.tcl) and the run (mssql_tproch_run.t2.tcl).
+  Columnstore stays OFF here — see mssql.t2col.yml for the columnar sub-tier.
+  NOTE: SQL Server's native advisor (Database Engine Tuning Advisor) is
+  Windows-only, so the Linux container gets curated tuning only (like PostgreSQL).
+  See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  tpch_queries:
+    unit: TPC-H query
+    sci: true
+
+services:
+  mssql:
+    environment:
+      MSSQL_MEMORY_LIMIT_MB: "5120"   # T1 max server memory (~62% of 8 GB)
+  postgres: # empty key will remove the unused service
+  mariadb: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb: # wait for SQL Server to finish starting up before benchmarking
+    depends_on:
+      mssql:
+        condition: service_healthy
+
+# T2 swaps in the maxdop=4 driver scripts, so the flow is defined here.
+flow:
+  - name: Build Schema
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB BUILD (T2 — maxdop 4, row store)
+        command: ./hammerdbcli auto /tmp/repo/db/mssql/tpch/mssql_tproch_buildschema.t2.tcl | tee /dev/stderr | awk '/query [0-9]+ completed in/{q++} END{if(q>0){"date +%s"|getline ts; printf("%s000000 tpch_queries=%d\n", ts, q)}}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Run Queries
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB QUERIES (T2 — maxdop 4)
+        command: ./hammerdbcli auto /tmp/repo/db/mssql/tpch/mssql_tproch_run.t2.tcl | tee /dev/stderr | awk 'END{"date +%s"|getline ts; printf("%s000000 tpch_queries=22\n", ts)}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Drop Schema
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB DROP
+        command: ./hammerdbcli auto /tmp/repo/db/mssql/tpch/mssql_tproch_deleteschema.tcl | tee /dev/stderr | awk '/query [0-9]+ completed in/{q++} END{if(q>0){"date +%s"|getline ts; printf("%s000000 tpch_queries=%d\n", ts, q)}}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true

--- a/benchmarks/tpch/mssql.t2col.yml
+++ b/benchmarks/tpch/mssql.t2col.yml
@@ -1,0 +1,61 @@
+---
+name: HammerDB MSSQL TPC-H benchmark (T2+ columnar)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-H on Microsoft SQL Server, tuning sub-tier T2+ (COLUMNAR). Same as
+  mssql.t2.yml but the schema is built with clustered columnstore enabled
+  (mssql_tproch_buildschema.t2col.tcl, mssqls_colstore true) — the strongest
+  analytical storage design SQL Server offers. This is the "best per engine"
+  variant; compare it against the row-store T2 to show the columnar energy floor.
+  See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  tpch_queries:
+    unit: TPC-H query
+    sci: true
+
+services:
+  mssql:
+    environment:
+      MSSQL_MEMORY_LIMIT_MB: "5120"   # T1 max server memory (~62% of 8 GB)
+  postgres: # empty key will remove the unused service
+  mariadb: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb: # wait for SQL Server to finish starting up before benchmarking
+    depends_on:
+      mssql:
+        condition: service_healthy
+
+# Columnar build + maxdop=4 run.
+flow:
+  - name: Build Schema
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB BUILD (T2+ — clustered columnstore)
+        command: ./hammerdbcli auto /tmp/repo/db/mssql/tpch/mssql_tproch_buildschema.t2col.tcl | tee /dev/stderr | awk '/query [0-9]+ completed in/{q++} END{if(q>0){"date +%s"|getline ts; printf("%s000000 tpch_queries=%d\n", ts, q)}}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Run Queries
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB QUERIES (T2+ — maxdop 4, columnstore)
+        command: ./hammerdbcli auto /tmp/repo/db/mssql/tpch/mssql_tproch_run.t2.tcl | tee /dev/stderr | awk 'END{"date +%s"|getline ts; printf("%s000000 tpch_queries=22\n", ts)}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Drop Schema
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB DROP
+        command: ./hammerdbcli auto /tmp/repo/db/mssql/tpch/mssql_tproch_deleteschema.tcl | tee /dev/stderr | awk '/query [0-9]+ completed in/{q++} END{if(q>0){"date +%s"|getline ts; printf("%s000000 tpch_queries=%d\n", ts, q)}}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true

--- a/benchmarks/tpch/mysql.t1.yml
+++ b/benchmarks/tpch/mysql.t1.yml
@@ -1,0 +1,45 @@
+---
+name: HammerDB MySQL TPC-H benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-H on MySQL, tuning tier T1 (envelope-sized). Identical engine config to
+  tpcc/mysql.t1.yml (hardware-sized, workload-agnostic). See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  tpch_queries:
+    unit: TPC-H query
+    sci: true
+
+services:
+  # T1 tuning: flags appended to mysqld by the official image entrypoint (it
+  # prepends `mysqld` when the command starts with `-`). Merged over compose.yml.
+  #
+  # Every literal below is recomputable from the 4-CPU / 8-GB envelope alone --
+  # see the derivation table in TUNING.md ("How each T1 number is derived").
+  # InnoDB with O_DIRECT owns the only page cache, so the buffer pool takes ~62%
+  # of the cgroup directly (vendor band: 50-75% of RAM).
+  mysql:
+    command:
+      - "--innodb-buffer-pool-size=5G"           # 62.5% of the 8-GB cgroup
+      - "--innodb-buffer-pool-instances=4"       # 5G / 4 = 1.25 GB each (>= 1 GB rule)
+      - "--innodb-redo-log-capacity=2G"          # MySQL 8.0.30+/9.x redo sizing
+      - "--innodb-flush-method=O_DIRECT"         # avoid double-buffering w/ page cache
+      - "--innodb-flush-log-at-trx-commit=1"     # full durability (engine default, explicit)
+      - "--innodb-io-capacity=2000"              # SSD-class
+      - "--innodb-io-capacity-max=4000"          # SSD-class
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+  postgres: # empty key will remove the unused service
+  mariadb: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb: # wait for MySQL to finish starting up before benchmarking
+    depends_on:
+      mysql:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['mysql.yml', 'flow']

--- a/benchmarks/tpch/mysql.t2.yml
+++ b/benchmarks/tpch/mysql.t2.yml
@@ -1,0 +1,90 @@
+---
+name: HammerDB MySQL TPC-H benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-H on MySQL, tuning tier T2 (workload-aware). T1 InnoDB sizing + OLAP session
+  buffers (large join/sort/tmp-table memory) since MySQL cannot parallelise a
+  single analytical query. A post-load "optimize" step adds curated analytical
+  indexes (non-fatal, --force) and refreshes optimizer statistics. No columnar
+  sub-tier (MySQL has no column store). See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  tpch_queries:
+    unit: TPC-H query
+    sci: true
+
+services:
+  mysql:
+    command:
+      - "--innodb-buffer-pool-size=5G"
+      - "--innodb-buffer-pool-instances=4"
+      - "--innodb-redo-log-capacity=2G"
+      - "--innodb-flush-method=O_DIRECT"
+      - "--innodb-flush-log-at-trx-commit=1"
+      - "--innodb-io-capacity=2000"
+      - "--innodb-io-capacity-max=4000"
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+      - "--join-buffer-size=128M"            # T2: large hash joins for OLAP
+      - "--sort-buffer-size=32M"             # T2: ORDER BY / GROUP BY
+      - "--read-rnd-buffer-size=16M"
+      - "--tmp-table-size=512M"              # T2: keep big GROUP BY temp tables in memory
+      - "--max-heap-table-size=512M"
+      - "--innodb-parallel-read-threads=4"   # T2: parallel scans (MySQL 8+)
+  postgres: # empty key will remove the unused service
+  mariadb: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb:
+    depends_on:
+      mysql:
+        condition: service_healthy
+
+flow:
+  - name: Build Schema
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB BUILD
+        command: ./hammerdbcli auto /tmp/repo/db/mysql/tpch/mysql_tproch_buildschema.tcl | tee /dev/stderr | awk '/query [0-9]+ completed in/{q++} END{if(q>0){"date +%s"|getline ts; printf("%s000000 tpch_queries=%d\n", ts, q)}}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Optimize schema (T2)
+    container: mysql_container
+    commands:
+      - type: console
+        note: T2 CURATED INDEXES + ANALYZE (non-fatal; VERIFY names)
+        command: |
+          mysql -uroot -pmysql --force tpch -e "
+            CREATE INDEX t2_l_shipdate ON lineitem (l_shipdate);
+            CREATE INDEX t2_l_partkey  ON lineitem (l_partkey);
+            CREATE INDEX t2_l_suppkey  ON lineitem (l_suppkey);
+            CREATE INDEX t2_o_orderdate ON orders (o_orderdate);
+            CREATE INDEX t2_o_custkey   ON orders (o_custkey);
+            CREATE INDEX t2_ps_suppkey  ON partsupp (ps_suppkey);
+          " || true
+          mysqlcheck -uroot -pmysql --analyze --databases tpch || true
+        shell: bash
+        log-stdout: true
+  - name: Run Queries
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB QUERIES
+        command: ./hammerdbcli auto /tmp/repo/db/mysql/tpch/mysql_tproch_run.tcl | tee /dev/stderr | awk 'END{"date +%s"|getline ts; printf("%s000000 tpch_queries=22\n", ts)}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Drop Schema
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB DROP
+        command: ./hammerdbcli auto /tmp/repo/db/mysql/tpch/mysql_tproch_deleteschema.tcl | tee /dev/stderr | awk '/query [0-9]+ completed in/{q++} END{if(q>0){"date +%s"|getline ts; printf("%s000000 tpch_queries=%d\n", ts, q)}}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true

--- a/benchmarks/tpch/oracle.t1.yml
+++ b/benchmarks/tpch/oracle.t1.yml
@@ -1,0 +1,61 @@
+---
+name: HammerDB Oracle TPC-H benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-H on Oracle Database Free, tuning tier T1 (envelope-sized). Same engine
+  tuning as tpcc/oracle.t1.yml. CAVEAT: Oracle Free is licence-capped at ~2 GB
+  RAM / 2 CPU threads (cannot use the 8-GB/4-CPU envelope); SGA/PGA ALTERs are
+  skipped under Automatic Memory Management. VERIFY on first run; see TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  tpch_queries:
+    unit: TPC-H query
+    sci: true
+
+services:
+  # oracle service intentionally NOT listed -> kept as-is from compose.yml
+  # (Oracle exposes no command-flag config; T1 is applied at runtime by the
+  # prepended flow step below).
+  postgres: # empty key will remove the unused service
+  mariadb: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb: # wait for Oracle to finish starting up before benchmarking
+    depends_on:
+      oracle:
+        condition: service_healthy
+    environment:
+      LD_LIBRARY_PATH: /home/instantclient_21_18
+
+# T1 tuning runs as a prepended flow step (Oracle has no command-flag config).
+# Retries until the listener answers, continues past ORA errors, never fails the
+# run. Connects to the CDB root (service FREE) as SYSDBA.
+#
+# WHY THESE NUMBERS LOOK NOTHING LIKE THE OTHER ENGINES': Oracle Database Free is
+# licence-capped at ~2 GB of database RAM (SGA+PGA) and 2 CPU threads, so T1 is
+# sized against THAT cap, not the 8-GB cgroup every other engine gets:
+#     1300M (SGA) + 500M (PGA) = 1800M of the 2048M cap, ~250M headroom.
+# The procedure is identical (vendor rule applied to the effective memory limit);
+# only the effective limit differs. Oracle Free therefore cannot fill the shared
+# envelope, and its absolute J/op is not comparable on equal-hardware terms.
+# See TUNING.md: "How each T1 number is derived" + "Threats to validity".
+flow-prepend:
+  - name: Tune Oracle (T1 envelope-sized)
+    container: oracle_container
+    commands:
+      - type: console
+        note: APPLY T1 SGA/PGA SIZING (capped by Oracle Free 2 GB limit)
+        command: |
+          i=0; while [ $i -lt 30 ]; do
+            printf 'WHENEVER SQLERROR CONTINUE\nALTER SYSTEM SET sga_target=1300M SCOPE=BOTH;\nALTER SYSTEM SET pga_aggregate_target=500M SCOPE=BOTH;\nSHOW PARAMETER sga_target\nSHOW PARAMETER pga_aggregate_target\nEXIT\n' \
+              | sqlplus -s -L sys/oracle@//localhost:1521/FREE as sysdba && break
+            i=$((i+1)); sleep 3
+          done; true
+        shell: bash
+        log-stdout: true
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['oracle.yml', 'flow']

--- a/benchmarks/tpch/oracle.t2.yml
+++ b/benchmarks/tpch/oracle.t2.yml
@@ -1,0 +1,96 @@
+---
+name: HammerDB Oracle TPC-H benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-H on Oracle Database Free, tuning tier T2 (workload-aware). T1 SGA/PGA tune
+  (prepended) + query parallel degree 4 (oracle_tproch_run.t2.tcl) + a post-load
+  optimize step (curated indexes + DBMS_STATS.GATHER_SCHEMA_STATS). Oracle has no
+  usable native advisor on Free, so it is curated-only.
+  CAVEAT: Oracle Free is licence-capped at ~2 GB RAM / 2 CPU threads, so degree=4
+  is bounded by the edition and the T1->T2 delta is expected to be small. VERIFY
+  the optimize step's stdout on first run (index names, stats). See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  tpch_queries:
+    unit: TPC-H query
+    sci: true
+
+services:
+  # oracle service kept as-is from compose.yml; tuning applied at runtime.
+  postgres: # empty key will remove the unused service
+  mariadb: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb:
+    depends_on:
+      oracle:
+        condition: service_healthy
+    environment:
+      LD_LIBRARY_PATH: /home/instantclient_21_18
+
+# T1 SGA/PGA sizing runs first (Oracle has no command-flag config).
+flow-prepend:
+  - name: Tune Oracle (T1 envelope-sized)
+    container: oracle_container
+    commands:
+      - type: console
+        note: APPLY T1 SGA/PGA SIZING (capped by Oracle Free 2 GB limit)
+        command: |
+          i=0; while [ $i -lt 30 ]; do
+            printf 'WHENEVER SQLERROR CONTINUE\nALTER SYSTEM SET sga_target=1300M SCOPE=BOTH;\nALTER SYSTEM SET pga_aggregate_target=500M SCOPE=BOTH;\nEXIT\n' \
+              | sqlplus -s -L sys/oracle@//localhost:1521/FREE as sysdba && break
+            i=$((i+1)); sleep 3
+          done; true
+        shell: bash
+        log-stdout: true
+
+flow:
+  - name: Build Schema
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB BUILD
+        command: ./hammerdbcli auto /tmp/repo/db/oracle/tpch/oracle_tproch_buildschema.tcl | tee /dev/stderr | awk '/query [0-9]+ completed in/{q++} END{if(q>0){"date +%s"|getline ts; printf("%s000000 tpch_queries=%d\n", ts, q)}}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Optimize schema (T2)
+    container: oracle_container
+    commands:
+      - type: console
+        note: T2 CURATED INDEXES + GATHER STATS (non-fatal; VERIFY names)
+        command: |
+          sqlplus -s -L system/oracle@//localhost:1521/FREEPDB1 <<'SQL' || true
+          WHENEVER SQLERROR CONTINUE
+          CREATE INDEX tpch.t2_l_shipdate ON tpch.lineitem(l_shipdate);
+          CREATE INDEX tpch.t2_l_partkey ON tpch.lineitem(l_partkey);
+          CREATE INDEX tpch.t2_l_suppkey ON tpch.lineitem(l_suppkey);
+          CREATE INDEX tpch.t2_o_orderdate ON tpch.orders(o_orderdate);
+          CREATE INDEX tpch.t2_o_custkey ON tpch.orders(o_custkey);
+          CREATE INDEX tpch.t2_ps_suppkey ON tpch.partsupp(ps_suppkey);
+          EXEC DBMS_STATS.GATHER_SCHEMA_STATS(ownname => 'TPCH', degree => 4);
+          EXIT
+          SQL
+        shell: bash
+        log-stdout: true
+  - name: Run Queries
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB QUERIES (T2 — parallel degree 4)
+        command: ./hammerdbcli auto /tmp/repo/db/oracle/tpch/oracle_tproch_run.t2.tcl | tee /dev/stderr | awk 'END{"date +%s"|getline ts; printf("%s000000 tpch_queries=22\n", ts)}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Drop Schema
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB DROP
+        command: ./hammerdbcli auto /tmp/repo/db/oracle/tpch/oracle_tproch_deleteschema.tcl | tee /dev/stderr | awk '/query [0-9]+ completed in/{q++} END{if(q>0){"date +%s"|getline ts; printf("%s000000 tpch_queries=%d\n", ts, q)}}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true

--- a/benchmarks/tpch/pg.t1.yml
+++ b/benchmarks/tpch/pg.t1.yml
@@ -1,0 +1,70 @@
+---
+name: HammerDB Postgres TPC-H benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-H on PostgreSQL, tuning tier T1 (envelope-sized). Same engine config as
+  tpcc/pg.t1.yml — T1 is hardware-sized, not workload-specialised; OLAP-specific
+  tuning (large work_mem, partitioning, parallel-heavy) is deferred to T2.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  tpch_queries: # functional unit (work done): number of TPC-H queries completed
+    unit: TPC-H query
+    sci: true
+
+services:
+  # T1 tuning: passed as `postgres -c key=val` flags, which the official image's
+  # entrypoint forwards verbatim. Merged over compose.yml's postgres service, so
+  # image / cpus / mem_limit / env / healthcheck are inherited unchanged.
+  #
+  # Every literal below is recomputable from the 4-CPU / 8-GB envelope alone --
+  # see the derivation table in TUNING.md ("How each T1 number is derived").
+  # Postgres reads *through* the OS page cache, so its vendor rule is a 25%
+  # shared_buffers plus a 75% effective_cache_size planner hint -- NOT the ~62%
+  # single-cache sizing InnoDB / SQL Server use. Same rule, different arithmetic.
+  postgres:
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_buffers=2GB"            # 25% of the 8-GB cgroup (PostgreSQL standard)
+      - "-c"
+      - "effective_cache_size=6GB"      # planner hint: 75% (OS page cache, not an allocation)
+      - "-c"
+      - "maintenance_work_mem=512MB"
+      - "-c"
+      - "work_mem=16MB"                 # neutral; TPC-H raises this in T2
+      - "-c"
+      - "wal_buffers=16MB"
+      - "-c"
+      - "min_wal_size=1GB"
+      - "-c"
+      - "max_wal_size=4GB"
+      - "-c"
+      - "checkpoint_completion_target=0.9"
+      - "-c"
+      - "default_statistics_target=100"
+      - "-c"
+      - "random_page_cost=1.1"          # SSD-class storage
+      - "-c"
+      - "effective_io_concurrency=200"  # SSD-class storage
+      - "-c"
+      - "max_worker_processes=4"        # = cpus
+      - "-c"
+      - "max_parallel_workers=4"        # = cpus
+      - "-c"
+      - "max_parallel_workers_per_gather=2"
+      - "-c"
+      - "max_parallel_maintenance_workers=2"
+  mariadb: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb: # wait for Postgres to finish starting up before benchmarking
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['pg.yml', 'flow']

--- a/benchmarks/tpch/pg.t2.yml
+++ b/benchmarks/tpch/pg.t2.yml
@@ -1,0 +1,118 @@
+---
+name: HammerDB Postgres TPC-H benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  TPC-H on PostgreSQL, tuning tier T2 (workload-aware, common/row-store design).
+  Builds on T1's envelope sizing with OLAP-specific config (large work_mem,
+  per-query parallelism = core count, higher statistics target, JIT), a raised
+  driver parallel degree (pg_tproch_run.t2.tcl), and a post-load "optimize"
+  step (curated analytical indexes + ANALYZE). PostgreSQL has no built-in
+  config/index advisor, so per the chosen policy it gets curated tuning only.
+  Durability left at default. See TUNING.md.
+  NOTE: the curated CREATE INDEX names assume HammerDB's standard TPC-H schema
+  (lineitem/orders/... lowercase in the default schema); they are IF NOT EXISTS +
+  non-fatal, but VERIFY against the built schema on first run.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  tpch_queries:
+    unit: TPC-H query
+    sci: true
+
+services:
+  # T2 = T1 envelope sizing + OLAP-specific config (vs T1: work_mem 16MB->256MB,
+  # per-gather workers 2->4, statistics target 100->200, JIT on). vu=1 for TPC-H,
+  # so a large work_mem is safe within the 8 GB container.
+  postgres:
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_buffers=2GB"
+      - "-c"
+      - "effective_cache_size=6GB"
+      - "-c"
+      - "maintenance_work_mem=512MB"
+      - "-c"
+      - "work_mem=256MB"                       # T2: large sorts/hashes for OLAP
+      - "-c"
+      - "wal_buffers=16MB"
+      - "-c"
+      - "min_wal_size=1GB"
+      - "-c"
+      - "max_wal_size=4GB"
+      - "-c"
+      - "checkpoint_completion_target=0.9"
+      - "-c"
+      - "default_statistics_target=200"        # T2: better plans on big tables
+      - "-c"
+      - "random_page_cost=1.1"
+      - "-c"
+      - "effective_io_concurrency=200"
+      - "-c"
+      - "max_worker_processes=4"
+      - "-c"
+      - "max_parallel_workers=4"
+      - "-c"
+      - "max_parallel_workers_per_gather=4"    # T2: full per-query parallelism
+      - "-c"
+      - "max_parallel_maintenance_workers=2"
+      - "-c"
+      - "jit=on"                               # T2: JIT helps long analytical queries
+  mariadb: # empty key will remove the unused service
+  mysql: # empty key will remove the unused service
+  oracle: # empty key will remove the unused service
+  mssql: # empty key will remove the unused service
+  db2: # empty key will remove the unused service
+  hammerdb: # wait for Postgres to finish starting up before benchmarking
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+# T2 changes the flow (a post-load optimize step is inserted, and the run step
+# uses the t2 driver script), so the flow is defined here rather than shared.
+flow:
+  - name: Build Schema
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB BUILD
+        command: ./hammerdbcli auto /tmp/repo/db/pg/tpch/pg_tproch_buildschema.tcl | tee /dev/stderr | awk '/query [0-9]+ completed in/{q++} END{if(q>0){"date +%s"|getline ts; printf("%s000000 tpch_queries=%d\n", ts, q)}}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Optimize schema (T2)
+    container: postgres_container
+    commands:
+      - type: console
+        note: T2 CURATED ANALYTICAL INDEXES + ANALYZE (non-fatal; VERIFY names)
+        command: |
+          psql "postgresql://postgres:postgres@localhost:5432/tpch" -v ON_ERROR_STOP=0 <<'SQL'
+          CREATE INDEX IF NOT EXISTS t2_l_shipdate ON lineitem (l_shipdate);
+          CREATE INDEX IF NOT EXISTS t2_l_partkey  ON lineitem (l_partkey);
+          CREATE INDEX IF NOT EXISTS t2_l_suppkey  ON lineitem (l_suppkey);
+          CREATE INDEX IF NOT EXISTS t2_o_orderdate ON orders (o_orderdate);
+          CREATE INDEX IF NOT EXISTS t2_o_custkey   ON orders (o_custkey);
+          CREATE INDEX IF NOT EXISTS t2_ps_suppkey  ON partsupp (ps_suppkey);
+          ANALYZE;
+          SQL
+        shell: bash
+        log-stdout: true
+  - name: Run Queries
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB QUERIES (T2 — parallel degree 4)
+        command: ./hammerdbcli auto /tmp/repo/db/pg/tpch/pg_tproch_run.t2.tcl | tee /dev/stderr | awk 'END{"date +%s"|getline ts; printf("%s000000 tpch_queries=22\n", ts)}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true
+  - name: Drop Schema
+    container: hammerdb_container
+    commands:
+      - type: console
+        note: RUN HAMMERDB DROP
+        command: ./hammerdbcli auto /tmp/repo/db/pg/tpch/pg_tproch_deleteschema.tcl | tee /dev/stderr | awk '/query [0-9]+ completed in/{q++} END{if(q>0){"date +%s"|getline ts; printf("%s000000 tpch_queries=%d\n", ts, q)}}'
+        shell: sh
+        log-stdout: true
+        read-sci-stdout: true

--- a/benchmarks/wikipedia/maria.t1.yml
+++ b/benchmarks/wikipedia/maria.t1.yml
@@ -1,0 +1,46 @@
+---
+name: BenchBase MariaDB Wikipedia benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  Wikipedia (BenchBase) on MariaDB, tuning tier T1 (envelope-sized). Same
+  hardware-sized InnoDB config as tpcc/maria.t1.yml; durability at default.
+  See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  wikipedia_requests:
+    unit: Wikipedia request
+    sci: true
+
+services:
+  # T1 tuning: flags appended to mariadbd by the image entrypoint. Merged over
+  # compose.yml. (buffer_pool_instances is omitted: a no-op on modern MariaDB.)
+  #
+  # Every literal below is recomputable from the 4-CPU / 8-GB envelope alone --
+  # see the derivation table in TUNING.md ("How each T1 number is derived").
+  # Same InnoDB rule as mysql.t1.yml: O_DIRECT makes the buffer pool the only
+  # cache, so it takes ~62% of the cgroup directly (vendor band: 50-75% of RAM).
+  mariadb:
+    command:
+      - "--innodb-buffer-pool-size=5G"           # 62.5% of the 8-GB cgroup
+      - "--innodb-log-file-size=2G"              # redo log sizing
+      - "--innodb-flush-method=O_DIRECT"         # avoid double-buffering w/ page cache
+      - "--innodb-flush-log-at-trx-commit=1"     # full durability (engine default, explicit)
+      - "--innodb-io-capacity=2000"              # SSD-class
+      - "--innodb-io-capacity-max=4000"          # SSD-class
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+  postgres: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase: # load driver; wait for the database to be healthy first
+    depends_on:
+      mariadb:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['maria.yml', 'flow']

--- a/benchmarks/wikipedia/maria.t2.yml
+++ b/benchmarks/wikipedia/maria.t2.yml
@@ -1,0 +1,39 @@
+---
+name: BenchBase MariaDB Wikipedia benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  Wikipedia (BenchBase) on MariaDB, tuning tier T2 (read-mostly serving). T1 InnoDB
+  sizing + OLTP write-path tuning. Config-only; shares the T0 flow. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  wikipedia_requests:
+    unit: Wikipedia request
+    sci: true
+
+services:
+  mariadb:
+    command:
+      - "--innodb-buffer-pool-size=5G"
+      - "--innodb-log-file-size=2G"
+      - "--innodb-flush-method=O_DIRECT"
+      - "--innodb-flush-log-at-trx-commit=1"
+      - "--innodb-io-capacity=2000"
+      - "--innodb-io-capacity-max=4000"
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+      - "--innodb-purge-threads=4"
+      - "--innodb-change-buffering=all"
+  postgres: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase:
+    depends_on:
+      mariadb:
+        condition: service_healthy
+
+flow: !include ['maria.yml', 'flow']

--- a/benchmarks/wikipedia/mssql.t1.yml
+++ b/benchmarks/wikipedia/mssql.t1.yml
@@ -1,0 +1,39 @@
+---
+name: BenchBase MSSQL Wikipedia benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  Wikipedia (BenchBase) on SQL Server, tuning tier T1 (envelope-sized). max
+  server memory via MSSQL_MEMORY_LIMIT_MB, as in tpcc/mssql.t1.yml. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  wikipedia_requests:
+    unit: Wikipedia request
+    sci: true
+
+services:
+  # T1 tuning: merged onto compose.yml's mssql environment (ACCEPT_EULA etc. kept).
+  #
+  # SQL Server manages its own buffer cache, so "max server memory" is the only
+  # envelope lever here; MAXDOP / cost-threshold are workload-specific -> T2.
+  # See the derivation table in TUNING.md ("How each T1 number is derived").
+  # Deliberate deviation from the vendor rule (leave 25-35% of RAM to the OS and
+  # SQLOS): we leave 37.5%, because under a hard cgroup limit an over-commit is a
+  # silent OOM-kill, not a swap slowdown.
+  mssql:
+    environment:
+      MSSQL_MEMORY_LIMIT_MB: "5120"   # max server memory; 62.5% of the 8-GB cgroup
+  postgres: # unused — empty key removes the service
+  mariadb: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase: # load driver; wait for the database to be healthy first
+    depends_on:
+      mssql:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['mssql.yml', 'flow']

--- a/benchmarks/wikipedia/mssql.t2.yml
+++ b/benchmarks/wikipedia/mssql.t2.yml
@@ -1,0 +1,31 @@
+---
+name: BenchBase MSSQL Wikipedia benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  Wikipedia (BenchBase) on SQL Server, tuning tier T2 (read-mostly serving). Only
+  injectable lever is max server memory (already set in T1) — finer tuning needs
+  sqlcmd (absent in the Linux image). CONFIG-PARITY (thin) T2 = T1. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  wikipedia_requests:
+    unit: Wikipedia request
+    sci: true
+
+services:
+  mssql:
+    environment:
+      MSSQL_MEMORY_LIMIT_MB: "5120"
+  postgres: # unused — empty key removes the service
+  mariadb: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase:
+    depends_on:
+      mssql:
+        condition: service_healthy
+
+flow: !include ['mssql.yml', 'flow']

--- a/benchmarks/wikipedia/mysql.t1.yml
+++ b/benchmarks/wikipedia/mysql.t1.yml
@@ -1,0 +1,47 @@
+---
+name: BenchBase MySQL Wikipedia benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  Wikipedia (BenchBase) on MySQL, tuning tier T1 (envelope-sized). Same
+  hardware-sized InnoDB config as tpcc/mysql.t1.yml; durability at default.
+  See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  wikipedia_requests:
+    unit: Wikipedia request
+    sci: true
+
+services:
+  # T1 tuning: flags appended to mysqld by the official image entrypoint (it
+  # prepends `mysqld` when the command starts with `-`). Merged over compose.yml.
+  #
+  # Every literal below is recomputable from the 4-CPU / 8-GB envelope alone --
+  # see the derivation table in TUNING.md ("How each T1 number is derived").
+  # InnoDB with O_DIRECT owns the only page cache, so the buffer pool takes ~62%
+  # of the cgroup directly (vendor band: 50-75% of RAM).
+  mysql:
+    command:
+      - "--innodb-buffer-pool-size=5G"           # 62.5% of the 8-GB cgroup
+      - "--innodb-buffer-pool-instances=4"       # 5G / 4 = 1.25 GB each (>= 1 GB rule)
+      - "--innodb-redo-log-capacity=2G"          # MySQL 8.0.30+/9.x redo sizing
+      - "--innodb-flush-method=O_DIRECT"         # avoid double-buffering w/ page cache
+      - "--innodb-flush-log-at-trx-commit=1"     # full durability (engine default, explicit)
+      - "--innodb-io-capacity=2000"              # SSD-class
+      - "--innodb-io-capacity-max=4000"          # SSD-class
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+  postgres: # unused — empty key removes the service
+  mariadb: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase: # load driver; wait for the database to be healthy first
+    depends_on:
+      mysql:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['mysql.yml', 'flow']

--- a/benchmarks/wikipedia/mysql.t2.yml
+++ b/benchmarks/wikipedia/mysql.t2.yml
@@ -1,0 +1,41 @@
+---
+name: BenchBase MySQL Wikipedia benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  Wikipedia (BenchBase) on MySQL, tuning tier T2 (read-mostly serving). T1 InnoDB
+  sizing + OLTP write-path tuning. Config-only; shares the T0 flow. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  wikipedia_requests:
+    unit: Wikipedia request
+    sci: true
+
+services:
+  mysql:
+    command:
+      - "--innodb-buffer-pool-size=5G"
+      - "--innodb-buffer-pool-instances=4"
+      - "--innodb-redo-log-capacity=2G"
+      - "--innodb-flush-method=O_DIRECT"
+      - "--innodb-flush-log-at-trx-commit=1"
+      - "--innodb-io-capacity=2000"
+      - "--innodb-io-capacity-max=4000"
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+      - "--innodb-purge-threads=4"
+      - "--innodb-change-buffering=all"
+      - "--innodb-adaptive-hash-index=ON"
+  postgres: # unused — empty key removes the service
+  mariadb: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase:
+    depends_on:
+      mysql:
+        condition: service_healthy
+
+flow: !include ['mysql.yml', 'flow']

--- a/benchmarks/wikipedia/oracle.t1.yml
+++ b/benchmarks/wikipedia/oracle.t1.yml
@@ -1,0 +1,61 @@
+---
+name: BenchBase Oracle Wikipedia benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  Wikipedia (BenchBase) on Oracle Database Free, tuning tier T1 (envelope-sized).
+  SGA/PGA sized by a prepended ALTER SYSTEM step, as in tpcc/oracle.t1.yml.
+  CAVEAT: Oracle Free is licence-capped at ~2 GB RAM / 2 CPU threads, so the
+  T0->T1 delta is expected to be small; ALTERs are skipped under Automatic Memory
+  Management. VERIFY on first run; see TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  wikipedia_requests:
+    unit: Wikipedia request
+    sci: true
+
+services:
+  # oracle service intentionally NOT listed -> kept as-is from compose.yml
+  # (Oracle exposes no command-flag config; T1 is applied at runtime by the
+  # prepended flow step below).
+  postgres: # unused — empty key removes the service
+  mariadb: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase: # load driver; wait for the database to be healthy first
+    depends_on:
+      oracle:
+        condition: service_healthy
+
+# T1 tuning runs as a prepended flow step (Oracle has no command-flag config).
+# Retries until the listener answers, continues past ORA errors, never fails the
+# run. Connects to the CDB root (service FREE) as SYSDBA.
+#
+# WHY THESE NUMBERS LOOK NOTHING LIKE THE OTHER ENGINES': Oracle Database Free is
+# licence-capped at ~2 GB of database RAM (SGA+PGA) and 2 CPU threads, so T1 is
+# sized against THAT cap, not the 8-GB cgroup every other engine gets:
+#     1300M (SGA) + 500M (PGA) = 1800M of the 2048M cap, ~250M headroom.
+# The procedure is identical (vendor rule applied to the effective memory limit);
+# only the effective limit differs. Oracle Free therefore cannot fill the shared
+# envelope, and its absolute J/op is not comparable on equal-hardware terms.
+# See TUNING.md: "How each T1 number is derived" + "Threats to validity".
+flow-prepend:
+  - name: Tune Oracle (T1 envelope-sized)
+    container: oracle_container
+    commands:
+      - type: console
+        note: APPLY T1 SGA/PGA SIZING (capped by Oracle Free 2 GB limit)
+        command: |
+          i=0; while [ $i -lt 30 ]; do
+            printf 'WHENEVER SQLERROR CONTINUE\nALTER SYSTEM SET sga_target=1300M SCOPE=BOTH;\nALTER SYSTEM SET pga_aggregate_target=500M SCOPE=BOTH;\nSHOW PARAMETER sga_target\nSHOW PARAMETER pga_aggregate_target\nEXIT\n' \
+              | sqlplus -s -L sys/oracle@//localhost:1521/FREE as sysdba && break
+            i=$((i+1)); sleep 3
+          done; true
+        shell: bash
+        log-stdout: true
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['oracle.yml', 'flow']

--- a/benchmarks/wikipedia/oracle.t2.yml
+++ b/benchmarks/wikipedia/oracle.t2.yml
@@ -1,0 +1,43 @@
+---
+name: BenchBase Oracle Wikipedia benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  Wikipedia (BenchBase) on Oracle Database Free, tuning tier T2 (read-mostly
+  serving). T1 SGA/PGA sizing (prepended). Free's 2 GB / 2-thread cap + no usable
+  native advisor make this a CONFIG-PARITY (thin) T2 = T1. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  wikipedia_requests:
+    unit: Wikipedia request
+    sci: true
+
+services:
+  postgres: # unused — empty key removes the service
+  mariadb: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase:
+    depends_on:
+      oracle:
+        condition: service_healthy
+
+flow-prepend:
+  - name: Tune Oracle (T1 envelope-sized)
+    container: oracle_container
+    commands:
+      - type: console
+        note: APPLY T1 SGA/PGA SIZING (capped by Oracle Free 2 GB limit)
+        command: |
+          i=0; while [ $i -lt 30 ]; do
+            printf 'WHENEVER SQLERROR CONTINUE\nALTER SYSTEM SET sga_target=1300M SCOPE=BOTH;\nALTER SYSTEM SET pga_aggregate_target=500M SCOPE=BOTH;\nSHOW PARAMETER sga_target\nSHOW PARAMETER pga_aggregate_target\nEXIT\n' \
+              | sqlplus -s -L sys/oracle@//localhost:1521/FREE as sysdba && break
+            i=$((i+1)); sleep 3
+          done; true
+        shell: bash
+        log-stdout: true
+
+flow: !include ['oracle.yml', 'flow']

--- a/benchmarks/wikipedia/pg.t1.yml
+++ b/benchmarks/wikipedia/pg.t1.yml
@@ -1,0 +1,71 @@
+---
+name: BenchBase PostgreSQL Wikipedia benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  Wikipedia (BenchBase) on PostgreSQL, tuning tier T1 (envelope-sized). Same
+  hardware-sized engine config as tpcc/pg.t1.yml; durability left at default.
+  See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  wikipedia_requests:
+    unit: Wikipedia request
+    sci: true
+
+services:
+  # T1 tuning: passed as `postgres -c key=val` flags, which the official image's
+  # entrypoint forwards verbatim. Merged over compose.yml's postgres service, so
+  # image / cpus / mem_limit / env / healthcheck are inherited unchanged.
+  #
+  # Every literal below is recomputable from the 4-CPU / 8-GB envelope alone --
+  # see the derivation table in TUNING.md ("How each T1 number is derived").
+  # Postgres reads *through* the OS page cache, so its vendor rule is a 25%
+  # shared_buffers plus a 75% effective_cache_size planner hint -- NOT the ~62%
+  # single-cache sizing InnoDB / SQL Server use. Same rule, different arithmetic.
+  postgres:
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_buffers=2GB"            # 25% of the 8-GB cgroup (PostgreSQL standard)
+      - "-c"
+      - "effective_cache_size=6GB"      # planner hint: 75% (OS page cache, not an allocation)
+      - "-c"
+      - "maintenance_work_mem=512MB"
+      - "-c"
+      - "work_mem=16MB"                 # neutral; TPC-H raises this in T2
+      - "-c"
+      - "wal_buffers=16MB"
+      - "-c"
+      - "min_wal_size=1GB"
+      - "-c"
+      - "max_wal_size=4GB"
+      - "-c"
+      - "checkpoint_completion_target=0.9"
+      - "-c"
+      - "default_statistics_target=100"
+      - "-c"
+      - "random_page_cost=1.1"          # SSD-class storage
+      - "-c"
+      - "effective_io_concurrency=200"  # SSD-class storage
+      - "-c"
+      - "max_worker_processes=4"        # = cpus
+      - "-c"
+      - "max_parallel_workers=4"        # = cpus
+      - "-c"
+      - "max_parallel_workers_per_gather=2"
+      - "-c"
+      - "max_parallel_maintenance_workers=2"
+  mariadb: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase: # load driver; wait for the database to be healthy first
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['pg.yml', 'flow']

--- a/benchmarks/wikipedia/pg.t2.yml
+++ b/benchmarks/wikipedia/pg.t2.yml
@@ -1,0 +1,67 @@
+---
+name: BenchBase PostgreSQL Wikipedia benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  Wikipedia (BenchBase) on PostgreSQL, tuning tier T2 (workload-aware, read-mostly
+  serving). Same T1 sizing plus the autovacuum-only delta listed below for the
+  write fraction. Config-only (BenchBase fixes the workload + schema), shares the
+  T0 flow. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  wikipedia_requests:
+    unit: Wikipedia request
+    sci: true
+
+services:
+  postgres:
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_buffers=2GB"
+      - "-c"
+      - "effective_cache_size=6GB"
+      - "-c"
+      - "maintenance_work_mem=512MB"
+      - "-c"
+      - "work_mem=16MB"
+      - "-c"
+      - "wal_buffers=16MB"
+      - "-c"
+      - "min_wal_size=1GB"
+      - "-c"
+      - "max_wal_size=4GB"
+      - "-c"
+      - "checkpoint_completion_target=0.9"
+      - "-c"
+      - "default_statistics_target=100"
+      - "-c"
+      - "random_page_cost=1.1"
+      - "-c"
+      - "effective_io_concurrency=200"
+      - "-c"
+      - "max_worker_processes=4"
+      - "-c"
+      - "max_parallel_workers=4"
+      - "-c"
+      - "max_parallel_workers_per_gather=2"
+      - "-c"
+      - "max_parallel_maintenance_workers=2"
+      # T2 delta versus pg.t1.yml: keep dead tuples in check during the write fraction.
+      - "-c"
+      - "autovacuum_vacuum_scale_factor=0.05"
+      - "-c"
+      - "autovacuum_vacuum_cost_limit=2000"
+  mariadb: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase:
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+flow: !include ['pg.yml', 'flow']

--- a/benchmarks/ycsb/maria.t1.yml
+++ b/benchmarks/ycsb/maria.t1.yml
@@ -1,0 +1,45 @@
+---
+name: BenchBase MariaDB YCSB benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  YCSB (BenchBase) on MariaDB, tuning tier T1 (envelope-sized). Same hardware-sized
+  InnoDB config as tpcc/maria.t1.yml; durability at default. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  ycsb_requests:
+    unit: YCSB request
+    sci: true
+
+services:
+  # T1 tuning: flags appended to mariadbd by the image entrypoint. Merged over
+  # compose.yml. (buffer_pool_instances is omitted: a no-op on modern MariaDB.)
+  #
+  # Every literal below is recomputable from the 4-CPU / 8-GB envelope alone --
+  # see the derivation table in TUNING.md ("How each T1 number is derived").
+  # Same InnoDB rule as mysql.t1.yml: O_DIRECT makes the buffer pool the only
+  # cache, so it takes ~62% of the cgroup directly (vendor band: 50-75% of RAM).
+  mariadb:
+    command:
+      - "--innodb-buffer-pool-size=5G"           # 62.5% of the 8-GB cgroup
+      - "--innodb-log-file-size=2G"              # redo log sizing
+      - "--innodb-flush-method=O_DIRECT"         # avoid double-buffering w/ page cache
+      - "--innodb-flush-log-at-trx-commit=1"     # full durability (engine default, explicit)
+      - "--innodb-io-capacity=2000"              # SSD-class
+      - "--innodb-io-capacity-max=4000"          # SSD-class
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+  postgres: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase: # load driver; wait for the database to be healthy first
+    depends_on:
+      mariadb:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['maria.yml', 'flow']

--- a/benchmarks/ycsb/maria.t2.yml
+++ b/benchmarks/ycsb/maria.t2.yml
@@ -1,0 +1,39 @@
+---
+name: BenchBase MariaDB YCSB benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  YCSB (BenchBase) on MariaDB, tuning tier T2 (key-value serving). T1 InnoDB sizing
+  + OLTP write-path tuning. Config-only; shares the T0 flow. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  ycsb_requests:
+    unit: YCSB request
+    sci: true
+
+services:
+  mariadb:
+    command:
+      - "--innodb-buffer-pool-size=5G"
+      - "--innodb-log-file-size=2G"
+      - "--innodb-flush-method=O_DIRECT"
+      - "--innodb-flush-log-at-trx-commit=1"
+      - "--innodb-io-capacity=2000"
+      - "--innodb-io-capacity-max=4000"
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+      - "--innodb-purge-threads=4"
+      - "--innodb-change-buffering=all"
+  postgres: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase:
+    depends_on:
+      mariadb:
+        condition: service_healthy
+
+flow: !include ['maria.yml', 'flow']

--- a/benchmarks/ycsb/mssql.t1.yml
+++ b/benchmarks/ycsb/mssql.t1.yml
@@ -1,0 +1,39 @@
+---
+name: BenchBase MSSQL YCSB benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  YCSB (BenchBase) on SQL Server, tuning tier T1 (envelope-sized). max server
+  memory via MSSQL_MEMORY_LIMIT_MB, as in tpcc/mssql.t1.yml. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  ycsb_requests:
+    unit: YCSB request
+    sci: true
+
+services:
+  # T1 tuning: merged onto compose.yml's mssql environment (ACCEPT_EULA etc. kept).
+  #
+  # SQL Server manages its own buffer cache, so "max server memory" is the only
+  # envelope lever here; MAXDOP / cost-threshold are workload-specific -> T2.
+  # See the derivation table in TUNING.md ("How each T1 number is derived").
+  # Deliberate deviation from the vendor rule (leave 25-35% of RAM to the OS and
+  # SQLOS): we leave 37.5%, because under a hard cgroup limit an over-commit is a
+  # silent OOM-kill, not a swap slowdown.
+  mssql:
+    environment:
+      MSSQL_MEMORY_LIMIT_MB: "5120"   # max server memory; 62.5% of the 8-GB cgroup
+  postgres: # unused — empty key removes the service
+  mariadb: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase: # load driver; wait for the database to be healthy first
+    depends_on:
+      mssql:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['mssql.yml', 'flow']

--- a/benchmarks/ycsb/mssql.t2.yml
+++ b/benchmarks/ycsb/mssql.t2.yml
@@ -1,0 +1,31 @@
+---
+name: BenchBase MSSQL YCSB benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  YCSB (BenchBase) on SQL Server, tuning tier T2 (key-value serving). Only
+  injectable lever is max server memory (set in T1); finer tuning needs sqlcmd
+  (absent in the Linux image). CONFIG-PARITY (thin) T2 = T1. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  ycsb_requests:
+    unit: YCSB request
+    sci: true
+
+services:
+  mssql:
+    environment:
+      MSSQL_MEMORY_LIMIT_MB: "5120"
+  postgres: # unused — empty key removes the service
+  mariadb: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase:
+    depends_on:
+      mssql:
+        condition: service_healthy
+
+flow: !include ['mssql.yml', 'flow']

--- a/benchmarks/ycsb/mysql.t1.yml
+++ b/benchmarks/ycsb/mysql.t1.yml
@@ -1,0 +1,46 @@
+---
+name: BenchBase MySQL YCSB benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  YCSB (BenchBase) on MySQL, tuning tier T1 (envelope-sized). Same hardware-sized
+  InnoDB config as tpcc/mysql.t1.yml; durability at default. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  ycsb_requests:
+    unit: YCSB request
+    sci: true
+
+services:
+  # T1 tuning: flags appended to mysqld by the official image entrypoint (it
+  # prepends `mysqld` when the command starts with `-`). Merged over compose.yml.
+  #
+  # Every literal below is recomputable from the 4-CPU / 8-GB envelope alone --
+  # see the derivation table in TUNING.md ("How each T1 number is derived").
+  # InnoDB with O_DIRECT owns the only page cache, so the buffer pool takes ~62%
+  # of the cgroup directly (vendor band: 50-75% of RAM).
+  mysql:
+    command:
+      - "--innodb-buffer-pool-size=5G"           # 62.5% of the 8-GB cgroup
+      - "--innodb-buffer-pool-instances=4"       # 5G / 4 = 1.25 GB each (>= 1 GB rule)
+      - "--innodb-redo-log-capacity=2G"          # MySQL 8.0.30+/9.x redo sizing
+      - "--innodb-flush-method=O_DIRECT"         # avoid double-buffering w/ page cache
+      - "--innodb-flush-log-at-trx-commit=1"     # full durability (engine default, explicit)
+      - "--innodb-io-capacity=2000"              # SSD-class
+      - "--innodb-io-capacity-max=4000"          # SSD-class
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+  postgres: # unused — empty key removes the service
+  mariadb: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase: # load driver; wait for the database to be healthy first
+    depends_on:
+      mysql:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['mysql.yml', 'flow']

--- a/benchmarks/ycsb/mysql.t2.yml
+++ b/benchmarks/ycsb/mysql.t2.yml
@@ -1,0 +1,41 @@
+---
+name: BenchBase MySQL YCSB benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  YCSB (BenchBase) on MySQL, tuning tier T2 (key-value serving). T1 InnoDB sizing +
+  OLTP write-path tuning. Config-only; shares the T0 flow. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  ycsb_requests:
+    unit: YCSB request
+    sci: true
+
+services:
+  mysql:
+    command:
+      - "--innodb-buffer-pool-size=5G"
+      - "--innodb-buffer-pool-instances=4"
+      - "--innodb-redo-log-capacity=2G"
+      - "--innodb-flush-method=O_DIRECT"
+      - "--innodb-flush-log-at-trx-commit=1"
+      - "--innodb-io-capacity=2000"
+      - "--innodb-io-capacity-max=4000"
+      - "--max-connections=200"
+      - "--table-open-cache=4000"
+      - "--innodb-purge-threads=4"
+      - "--innodb-change-buffering=all"
+      - "--innodb-adaptive-hash-index=ON"
+  postgres: # unused — empty key removes the service
+  mariadb: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase:
+    depends_on:
+      mysql:
+        condition: service_healthy
+
+flow: !include ['mysql.yml', 'flow']

--- a/benchmarks/ycsb/oracle.t1.yml
+++ b/benchmarks/ycsb/oracle.t1.yml
@@ -1,0 +1,60 @@
+---
+name: BenchBase Oracle YCSB benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  YCSB (BenchBase) on Oracle Database Free, tuning tier T1 (envelope-sized).
+  SGA/PGA sized by a prepended ALTER SYSTEM step, as in tpcc/oracle.t1.yml.
+  CAVEAT: Oracle Free is licence-capped at ~2 GB RAM / 2 CPU threads; ALTERs are
+  skipped under Automatic Memory Management. VERIFY on first run; see TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  ycsb_requests:
+    unit: YCSB request
+    sci: true
+
+services:
+  # oracle service intentionally NOT listed -> kept as-is from compose.yml
+  # (Oracle exposes no command-flag config; T1 is applied at runtime by the
+  # prepended flow step below).
+  postgres: # unused — empty key removes the service
+  mariadb: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase: # load driver; wait for the database to be healthy first
+    depends_on:
+      oracle:
+        condition: service_healthy
+
+# T1 tuning runs as a prepended flow step (Oracle has no command-flag config).
+# Retries until the listener answers, continues past ORA errors, never fails the
+# run. Connects to the CDB root (service FREE) as SYSDBA.
+#
+# WHY THESE NUMBERS LOOK NOTHING LIKE THE OTHER ENGINES': Oracle Database Free is
+# licence-capped at ~2 GB of database RAM (SGA+PGA) and 2 CPU threads, so T1 is
+# sized against THAT cap, not the 8-GB cgroup every other engine gets:
+#     1300M (SGA) + 500M (PGA) = 1800M of the 2048M cap, ~250M headroom.
+# The procedure is identical (vendor rule applied to the effective memory limit);
+# only the effective limit differs. Oracle Free therefore cannot fill the shared
+# envelope, and its absolute J/op is not comparable on equal-hardware terms.
+# See TUNING.md: "How each T1 number is derived" + "Threats to validity".
+flow-prepend:
+  - name: Tune Oracle (T1 envelope-sized)
+    container: oracle_container
+    commands:
+      - type: console
+        note: APPLY T1 SGA/PGA SIZING (capped by Oracle Free 2 GB limit)
+        command: |
+          i=0; while [ $i -lt 30 ]; do
+            printf 'WHENEVER SQLERROR CONTINUE\nALTER SYSTEM SET sga_target=1300M SCOPE=BOTH;\nALTER SYSTEM SET pga_aggregate_target=500M SCOPE=BOTH;\nSHOW PARAMETER sga_target\nSHOW PARAMETER pga_aggregate_target\nEXIT\n' \
+              | sqlplus -s -L sys/oracle@//localhost:1521/FREE as sysdba && break
+            i=$((i+1)); sleep 3
+          done; true
+        shell: bash
+        log-stdout: true
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['oracle.yml', 'flow']

--- a/benchmarks/ycsb/oracle.t2.yml
+++ b/benchmarks/ycsb/oracle.t2.yml
@@ -1,0 +1,43 @@
+---
+name: BenchBase Oracle YCSB benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  YCSB (BenchBase) on Oracle Database Free, tuning tier T2 (key-value serving). T1
+  SGA/PGA sizing (prepended). Free's 2 GB / 2-thread cap + no usable native advisor
+  make this a CONFIG-PARITY (thin) T2 = T1. See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  ycsb_requests:
+    unit: YCSB request
+    sci: true
+
+services:
+  postgres: # unused — empty key removes the service
+  mariadb: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase:
+    depends_on:
+      oracle:
+        condition: service_healthy
+
+flow-prepend:
+  - name: Tune Oracle (T1 envelope-sized)
+    container: oracle_container
+    commands:
+      - type: console
+        note: APPLY T1 SGA/PGA SIZING (capped by Oracle Free 2 GB limit)
+        command: |
+          i=0; while [ $i -lt 30 ]; do
+            printf 'WHENEVER SQLERROR CONTINUE\nALTER SYSTEM SET sga_target=1300M SCOPE=BOTH;\nALTER SYSTEM SET pga_aggregate_target=500M SCOPE=BOTH;\nSHOW PARAMETER sga_target\nSHOW PARAMETER pga_aggregate_target\nEXIT\n' \
+              | sqlplus -s -L sys/oracle@//localhost:1521/FREE as sysdba && break
+            i=$((i+1)); sleep 3
+          done; true
+        shell: bash
+        log-stdout: true
+
+flow: !include ['oracle.yml', 'flow']

--- a/benchmarks/ycsb/pg.t1.yml
+++ b/benchmarks/ycsb/pg.t1.yml
@@ -1,0 +1,71 @@
+---
+name: BenchBase PostgreSQL YCSB benchmark (T1 envelope-sized)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  YCSB (BenchBase) on PostgreSQL, tuning tier T1 (envelope-sized). Same
+  hardware-sized engine config as tpcc/pg.t1.yml; durability left at default.
+  See TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  ycsb_requests:
+    unit: YCSB request
+    sci: true
+
+services:
+  # T1 tuning: passed as `postgres -c key=val` flags, which the official image's
+  # entrypoint forwards verbatim. Merged over compose.yml's postgres service, so
+  # image / cpus / mem_limit / env / healthcheck are inherited unchanged.
+  #
+  # Every literal below is recomputable from the 4-CPU / 8-GB envelope alone --
+  # see the derivation table in TUNING.md ("How each T1 number is derived").
+  # Postgres reads *through* the OS page cache, so its vendor rule is a 25%
+  # shared_buffers plus a 75% effective_cache_size planner hint -- NOT the ~62%
+  # single-cache sizing InnoDB / SQL Server use. Same rule, different arithmetic.
+  postgres:
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_buffers=2GB"            # 25% of the 8-GB cgroup (PostgreSQL standard)
+      - "-c"
+      - "effective_cache_size=6GB"      # planner hint: 75% (OS page cache, not an allocation)
+      - "-c"
+      - "maintenance_work_mem=512MB"
+      - "-c"
+      - "work_mem=16MB"                 # neutral; TPC-H raises this in T2
+      - "-c"
+      - "wal_buffers=16MB"
+      - "-c"
+      - "min_wal_size=1GB"
+      - "-c"
+      - "max_wal_size=4GB"
+      - "-c"
+      - "checkpoint_completion_target=0.9"
+      - "-c"
+      - "default_statistics_target=100"
+      - "-c"
+      - "random_page_cost=1.1"          # SSD-class storage
+      - "-c"
+      - "effective_io_concurrency=200"  # SSD-class storage
+      - "-c"
+      - "max_worker_processes=4"        # = cpus
+      - "-c"
+      - "max_parallel_workers=4"        # = cpus
+      - "-c"
+      - "max_parallel_workers_per_gather=2"
+      - "-c"
+      - "max_parallel_maintenance_workers=2"
+  mariadb: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase: # load driver; wait for the database to be healthy first
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+# Same benchmark flow as the default (T0) scenario.
+flow: !include ['pg.yml', 'flow']

--- a/benchmarks/ycsb/pg.t2.yml
+++ b/benchmarks/ycsb/pg.t2.yml
@@ -1,0 +1,65 @@
+---
+name: BenchBase PostgreSQL YCSB benchmark (T2 workload-aware)
+author: Didi Hoffmann <didi@green-coding.berlin)
+description: >
+  YCSB (BenchBase) on PostgreSQL, tuning tier T2 (key-value serving). T1 sizing +
+  aggressive autovacuum for the write mix. Config-only; shares the T0 flow. See
+  TUNING.md.
+
+compose-file: !include compose.yml
+
+custom_metrics:
+  ycsb_requests:
+    unit: YCSB request
+    sci: true
+
+services:
+  postgres:
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_buffers=2GB"
+      - "-c"
+      - "effective_cache_size=6GB"
+      - "-c"
+      - "maintenance_work_mem=512MB"
+      - "-c"
+      - "work_mem=16MB"
+      - "-c"
+      - "wal_buffers=16MB"
+      - "-c"
+      - "min_wal_size=1GB"
+      - "-c"
+      - "max_wal_size=4GB"
+      - "-c"
+      - "checkpoint_completion_target=0.9"
+      - "-c"
+      - "default_statistics_target=100"
+      - "-c"
+      - "random_page_cost=1.1"
+      - "-c"
+      - "effective_io_concurrency=200"
+      - "-c"
+      - "max_worker_processes=4"
+      - "-c"
+      - "max_parallel_workers=4"
+      - "-c"
+      - "max_parallel_workers_per_gather=2"
+      - "-c"
+      - "max_parallel_maintenance_workers=2"
+      - "-c"
+      - "autovacuum_vacuum_scale_factor=0.05"
+      - "-c"
+      - "autovacuum_vacuum_cost_limit=2000"
+  mariadb: # unused — empty key removes the service
+  mysql: # unused — empty key removes the service
+  oracle: # unused — empty key removes the service
+  mssql: # unused — empty key removes the service
+  db2: # unused — empty key removes the service
+  hammerdb: # unused — empty key removes the service
+  benchbase:
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+flow: !include ['pg.yml', 'flow']

--- a/check_repo.py
+++ b/check_repo.py
@@ -9,7 +9,7 @@ parameters, otherwise the energy/throughput numbers are not comparable.
 Because GMT refuses to `!include` a compose file from a parent directory, each
 benchmark folder (``benchmarks/tpcc/``, ``benchmarks/tpch/``, ...) carries its
 own copy of ``compose.yml`` next to the usage scenarios. Copies drift, so this
-script enforces three invariants:
+script enforces four invariants:
 
   1. Every ``compose.yml`` in the repo is byte-for-byte identical (the per-folder
      copies must match the root source of truth).
@@ -19,6 +19,10 @@ script enforces three invariants:
   3. For each benchmark, the per-engine driver scripts use the same fairness
      knobs (virtual users, scale factor, terminals, duration, ...) across all
      databases.
+  4. For each engine, the T1 tuning payload is byte-for-byte identical across all
+     benchmarks — comments included. T1 is hardware-sized and workload-agnostic
+     (TUNING.md), so a per-benchmark difference is drift, and a *missing comment*
+     is the provenance a reviewer needs to reproduce the number going missing.
 
 Exit code is 0 when everything is consistent, 1 otherwise. Run it from anywhere;
 paths are resolved relative to this file.
@@ -75,6 +79,20 @@ TCL_KNOBS = {
 # <weights> live inside <works>/<work>; the rest are top-level.
 XML_TOP_KNOBS = ["scalefactor", "terminals", "batchsize", "isolation"]
 XML_WORK_KNOBS = ["time", "rate", "weights"]
+
+
+def tier_of(path: Path) -> str:
+    """Map a driver-script filename to its tuning tier via the dotted suffix
+    before the extension: ``pg_tproch_run.tcl`` -> ``base``,
+    ``pg_tproch_run.t2.tcl`` -> ``t2``, ``..._buildschema.t2col.tcl`` -> ``t2col``,
+    ``pg_wikipedia_config.xml`` -> ``base``, ``..._config.t2.xml`` -> ``t2``.
+
+    Tiers add driver-script variants that deliberately change tuning knobs (e.g.
+    the parallel degree), so fairness knobs are compared WITHIN a tier across
+    engines, never across tiers."""
+    stem = path.name[: -len(path.suffix)] if path.suffix else path.name
+    parts = stem.split(".")
+    return parts[1] if len(parts) > 1 else "base"
 
 
 class Reporter:
@@ -204,15 +222,17 @@ def check_compose_resources(rep: Reporter) -> None:
 # --------------------------------------------------------------------------- #
 # Check 3: benchmark parameters are the same for every database
 # --------------------------------------------------------------------------- #
-def extract_tcl_knobs(benchmark: str, db: str) -> dict[str, str] | None:
-    """Extract fairness knobs from a HammerDB engine's build + run scripts.
-    Returns None if the engine has no scripts for this benchmark."""
+def extract_tcl_knobs(benchmark: str, db: str, tier: str = "base") -> dict[str, str] | None:
+    """Extract fairness knobs from a HammerDB engine's build + run scripts for one
+    tuning tier. Returns None if the engine has no scripts for that tier."""
     bench_dir = REPO / "db" / db / benchmark
     if not bench_dir.is_dir():
         return None
 
     text = ""
     for tcl in sorted(bench_dir.glob("*.tcl")):
+        if tier_of(tcl) != tier:
+            continue
         text += "\n" + tcl.read_text()
     if not text.strip():
         return None
@@ -230,14 +250,14 @@ def extract_tcl_knobs(benchmark: str, db: str) -> dict[str, str] | None:
     return found
 
 
-def extract_xml_knobs(benchmark: str, db: str) -> dict[str, str] | None:
-    """Extract fairness knobs from a BenchBase engine's XML config. Returns None
-    if the engine has no config for this benchmark."""
+def extract_xml_knobs(benchmark: str, db: str, tier: str = "base") -> dict[str, str] | None:
+    """Extract fairness knobs from a BenchBase engine's XML config for one tuning
+    tier. Returns None if the engine has no config for that tier."""
     bench_dir = REPO / "db" / db / benchmark
     if not bench_dir.is_dir():
         return None
 
-    configs = sorted(bench_dir.glob("*config*.xml"))
+    configs = sorted(c for c in bench_dir.glob("*config*.xml") if tier_of(c) == tier)
     if not configs:
         return None
 
@@ -258,50 +278,219 @@ def extract_xml_knobs(benchmark: str, db: str) -> dict[str, str] | None:
     return found
 
 
+def discover_tiers(benchmark: str, is_hammerdb: bool) -> list[str]:
+    """Every tuning tier that has driver scripts for this benchmark, across all
+    engines. 'base' is always first; the rest (t1, t2, t2col, ...) follow sorted."""
+    pattern = "*.tcl" if is_hammerdb else "*config*.xml"
+    tiers: set[str] = set()
+    for db in DATABASES:
+        bench_dir = REPO / "db" / db / benchmark
+        if not bench_dir.is_dir():
+            continue
+        for f in bench_dir.glob(pattern):
+            tiers.add(tier_of(f))
+    tiers.discard("base")
+    return ["base", *sorted(tiers)]
+
+
 def check_benchmark_params(rep: Reporter) -> None:
-    rep.section("3. Benchmark parameters are equal across databases")
+    rep.section("3. Benchmark parameters are equal across databases (per tier)")
 
     for benchmark in BENCHMARKS:
-        extractor = (
-            extract_tcl_knobs if benchmark in HAMMERDB_BENCHMARKS else extract_xml_knobs
-        )
+        is_hammerdb = benchmark in HAMMERDB_BENCHMARKS
+        extractor = extract_tcl_knobs if is_hammerdb else extract_xml_knobs
 
-        per_db = {}
-        for db in DATABASES:
-            knobs = extractor(benchmark, db)
-            if knobs is None:
+        for tier in discover_tiers(benchmark, is_hammerdb):
+            per_db = {}
+            for db in DATABASES:
+                knobs = extractor(benchmark, db, tier)
+                if knobs is None:
+                    continue
+                # A sub-tier (t2, t2col, ...) only restates the knobs it
+                # re-tunes; everything else is inherited from the engine's base
+                # tier. Most importantly build-phase knobs (e.g.
+                # num_tpch_threads) live in the base buildschema and a run-only
+                # sub-tier reuses them. Fill those in from base so we compare the
+                # effective config, not just what the sub-tier happens to repeat.
+                if tier != "base":
+                    base = extractor(benchmark, db, "base")
+                    if base is not None:
+                        knobs = {**base, **knobs}
+                per_db[db] = knobs
+
+            label = benchmark if tier == "base" else f"{benchmark} [{tier}]"
+            print(f"\n  [{label}] engines: {', '.join(per_db) or '(none found)'}")
+            if not per_db:
+                if tier == "base":
+                    rep.warn(f"{label}: no driver scripts found")
                 continue
-            per_db[db] = knobs
 
-        print(f"\n  [{benchmark}] engines: {', '.join(per_db) or '(none found)'}")
-        if not per_db:
-            rep.warn(f"{benchmark}: no driver scripts found")
+            # A tier only one engine implements (e.g. columnar t2col on mssql) has
+            # nothing to compare across engines — acknowledge and move on.
+            if tier != "base" and len(per_db) == 1:
+                rep.ok(f"{label}: only {next(iter(per_db))} implements this tier")
+                continue
+
+            all_knobs = sorted({k for knobs in per_db.values() for k in knobs})
+            if not all_knobs:
+                rep.warn(f"{label}: no known fairness knobs found in driver scripts")
+                continue
+
+            for knob in all_knobs:
+                present = {db: knobs[knob] for db, knobs in per_db.items() if knob in knobs}
+                absent = [db for db in per_db if knob not in per_db[db]]
+                distinct = set(present.values())
+
+                if len(distinct) == 1 and not absent:
+                    rep.ok(f"{label}.{knob} = {next(iter(distinct))} (all engines)")
+                elif len(distinct) == 1 and absent:
+                    # Same value where defined, but some engines don't set it.
+                    rep.warn(
+                        f"{label}.{knob} = {next(iter(distinct))} but not set for: "
+                        f"{', '.join(absent)}"
+                    )
+                else:
+                    rep.fail(
+                        f"{label}.{knob} differs: "
+                        + ", ".join(f"{db}={val}" for db, val in sorted(present.items()))
+                        + (f" (absent: {', '.join(absent)})" if absent else "")
+                    )
+
+
+# --------------------------------------------------------------------------- #
+# Check 4: the T1 tuning payload is identical across benchmarks, per engine
+# --------------------------------------------------------------------------- #
+# The compose service that each engine's scenarios tune.
+T1_SERVICE_OF = {
+    "pg": "postgres",
+    "maria": "mariadb",
+    "mysql": "mysql",
+    "oracle": "oracle",
+    "mssql": "mssql",
+    "db2": "db2",
+}
+
+# Db2 is the one engine whose *service* block legitimately varies per benchmark
+# (it carries DBNAME=tpcc vs tpch), and whose flow-prepend names that database.
+# So compare only its flow-prepend, with the database name normalised away.
+T1_FLOW_ONLY = {"db2"}
+T1_DBNAME_RE = re.compile(r"\b(?:tpcc|tpch)\b")
+
+
+def _indent(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def extract_t1_payload(benchmark: str, db: str) -> str | None:
+    """Return the T1 *tuning payload* of benchmarks/<benchmark>/<db>.t1.yml as raw
+    text: the engine's service block (with the comments that justify each knob),
+    plus the `flow-prepend:` tuning step for engines that have no command-flag
+    config (Oracle, Db2). None when the scenario does not exist.
+
+    Everything else in the file — description, custom_metrics, which services are
+    removed, the load driver, the `flow:` include — is benchmark-specific and is
+    deliberately not compared. Raw text rather than parsed YAML, because the
+    per-knob provenance comments are exactly what must not drift.
+    """
+    path = REPO / "benchmarks" / benchmark / f"{db}.t1.yml"
+    if not path.is_file():
+        return None
+
+    lines = path.read_text().splitlines()
+    chunks: list[str] = []
+
+    if db not in T1_FLOW_ONLY:
+        svc = T1_SERVICE_OF[db]
+        si = next((i for i, l in enumerate(lines) if l.rstrip() == "services:"), None)
+        if si is None:
+            return None
+        j = si + 1
+        block: list[str] = []
+        # the engine preamble: contiguous indent-2 comments right under `services:`
+        while j < len(lines) and lines[j].startswith("  #"):
+            block.append(lines[j])
+            j += 1
+        # the engine's own service key and its indented body (absent for Oracle,
+        # which is kept as-is from compose.yml and tuned via flow-prepend)
+        if j < len(lines) and lines[j].rstrip() == f"  {svc}:":
+            block.append(lines[j])
+            j += 1
+            while j < len(lines) and (not lines[j].strip() or _indent(lines[j]) >= 4):
+                block.append(lines[j])
+                j += 1
+        while block and not block[-1].strip():
+            block.pop()
+        chunks.append("\n".join(block))
+
+    fi = next((i for i, l in enumerate(lines) if l.rstrip() == "flow-prepend:"), None)
+    if fi is not None:
+        start = fi
+        while start - 1 >= 0 and lines[start - 1].startswith("#"):
+            start -= 1
+        end = fi + 1
+        while end < len(lines) and (
+            not lines[end].strip() or lines[end].startswith((" ", "\t"))
+        ):
+            end += 1
+        block = lines[start:end]
+        while block and not block[-1].strip():
+            block.pop()
+        chunks.append("\n".join(block))
+
+    payload = "\n".join(c for c in chunks if c.strip())
+    if db in T1_FLOW_ONLY:
+        payload = T1_DBNAME_RE.sub("@DB@", payload)
+    return payload or None
+
+
+def check_t1_identical(rep: Reporter) -> None:
+    rep.section("4. T1 tuning payload is identical across benchmarks (per engine)")
+
+    for db in DATABASES:
+        payloads = {
+            b: p
+            for b in BENCHMARKS
+            if (p := extract_t1_payload(b, db)) is not None
+        }
+        if not payloads:
+            rep.warn(f"{db}: no T1 scenarios found")
+            continue
+        if len(payloads) == 1:
+            rep.ok(f"{db}.t1: only {next(iter(payloads))} ships this engine")
             continue
 
-        all_knobs = sorted({k for knobs in per_db.values() for k in knobs})
-        if not all_knobs:
-            rep.warn(f"{benchmark}: no known fairness knobs found in driver scripts")
+        groups: dict[str, list[str]] = {}
+        for bench, payload in payloads.items():
+            groups.setdefault(payload, []).append(bench)
+
+        if len(groups) == 1:
+            note = " (flow-prepend only; DBNAME normalised)" if db in T1_FLOW_ONLY else ""
+            rep.ok(f"{db}.t1 = same tuning in {', '.join(sorted(payloads))}{note}")
             continue
 
-        for knob in all_knobs:
-            present = {db: knobs[knob] for db, knobs in per_db.items() if knob in knobs}
-            absent = [db for db in per_db if knob not in per_db[db]]
-            distinct = set(present.values())
-
-            if len(distinct) == 1 and not absent:
-                rep.ok(f"{benchmark}.{knob} = {next(iter(distinct))} (all engines)")
-            elif len(distinct) == 1 and absent:
-                # Same value where defined, but some engines don't set it.
-                rep.warn(
-                    f"{benchmark}.{knob} = {next(iter(distinct))} but not set for: "
-                    f"{', '.join(absent)}"
-                )
+        rep.fail(
+            f"{db}.t1 tuning payload differs across benchmarks: "
+            + " | ".join("{" + ", ".join(sorted(bs)) + "}" for bs in groups.values())
+        )
+        # Point at the first divergent line so the drift is actionable.
+        ref_bench = sorted(payloads)[0]
+        ref = payloads[ref_bench].splitlines()
+        for bench in sorted(payloads):
+            if bench == ref_bench:
+                continue
+            other = payloads[bench].splitlines()
+            for n, (a, b) in enumerate(zip(ref, other), start=1):
+                if a != b:
+                    print(f"      {ref_bench} vs {bench}, first diff at payload line {n}:")
+                    print(f"        - {a.strip()}")
+                    print(f"        + {b.strip()}")
+                    break
             else:
-                rep.fail(
-                    f"{benchmark}.{knob} differs: "
-                    + ", ".join(f"{db}={val}" for db, val in sorted(present.items()))
-                    + (f" (absent: {', '.join(absent)})" if absent else "")
-                )
+                if len(ref) != len(other):
+                    print(
+                        f"      {bench}: {len(other)} payload lines vs "
+                        f"{len(ref)} in {ref_bench}"
+                    )
 
 
 def main() -> int:
@@ -311,6 +500,7 @@ def main() -> int:
     check_compose_identical(rep)
     check_compose_resources(rep)
     check_benchmark_params(rep)
+    check_t1_identical(rep)
 
     print()
     if rep.failures:

--- a/db/db2/tpch/db2_tproch_buildschema.t2col.tcl
+++ b/db/db2/tpch/db2_tproch_buildschema.t2col.tcl
@@ -1,0 +1,26 @@
+#!/bin/tclsh
+# maintainer: Pooja Jain
+# T2+ (COLUMNAR sub-tier) build for Db2 TPC-H: builds the tables as BLU
+# column-organized (db2_tpch_organizeby COLUMN) instead of row (NONE) — Db2's
+# strongest analytical design. Requires the instance in analytic mode
+# (DB2_WORKLOAD=ANALYTICS); the t2col scenario sets that before this build.
+
+puts "SETTING CONFIGURATION"
+dbset db db2
+dbset bm TPC-H
+
+diset connection db2_def_user db2inst1
+diset connection db2_def_pass ibmdb2
+diset connection db2_def_dbase tpch
+
+diset tpch db2_scale_fact 1
+diset tpch db2_num_tpch_threads 4
+diset tpch db2_tpch_user db2inst1
+diset tpch db2_tpch_pass ibmdb2
+diset tpch db2_tpch_dbase tpch
+diset tpch db2_tpch_def_tab USERSPACE1
+diset tpch db2_tpch_organizeby COLUMN
+
+puts "SCHEMA BUILD STARTED"
+buildschema
+puts "SCHEMA BUILD COMPLETED"

--- a/db/mssql/tpch/mssql_tproch_buildschema.t2.tcl
+++ b/db/mssql/tpch/mssql_tproch_buildschema.t2.tcl
@@ -1,0 +1,34 @@
+#!/bin/tclsh
+# maintainer: Pooja Jain
+# T2 (workload-aware, COMMON / row-store) build for SQL Server TPC-H: raises
+# build MAXDOP from 2 to 4; columnstore stays OFF (row store). The columnar
+# sub-tier is mssql_tproch_buildschema.t2col.tcl.
+
+puts "SETTING CONFIGURATION"
+dbset db mssqls
+dbset bm TPC-H
+
+diset connection mssqls_tcp true
+diset connection mssqls_port 1433
+diset connection mssqls_azure false
+diset connection mssqls_encrypt_connection true
+diset connection mssqls_trust_server_cert true
+diset connection mssqls_authentication windows
+diset connection mssqls_server {(local)}
+diset connection mssqls_linux_server mssql_container
+diset connection mssqls_uid sa
+diset connection mssqls_pass Hammerdb_2024
+diset connection mssqls_linux_authent sql
+diset connection mssqls_linux_odbc {ODBC Driver 18 for SQL Server}
+
+diset tpch mssqls_scale_fact 1
+diset tpch mssqls_maxdop 4
+diset tpch mssqls_num_tpch_threads 4
+diset tpch mssqls_tpch_dbase tpch
+diset tpch mssqls_colstore false
+# load via INSERTs, not bcp: the hammerdb image has the ODBC driver but no bcp binary
+diset tpch mssqls_tpch_use_bcp false
+
+puts "SCHEMA BUILD STARTED"
+buildschema
+puts "SCHEMA BUILD COMPLETED"

--- a/db/mssql/tpch/mssql_tproch_buildschema.t2col.tcl
+++ b/db/mssql/tpch/mssql_tproch_buildschema.t2col.tcl
@@ -1,0 +1,36 @@
+#!/bin/tclsh
+# maintainer: Pooja Jain
+# T2+ (COLUMNAR sub-tier) build for SQL Server TPC-H: enables HammerDB's
+# clustered columnstore option (mssqls_colstore true) so the TPC-H tables are
+# built as columnstore — the strongest analytical design SQL Server offers.
+# MAXDOP raised to 4. This is the columnar counterpart to the row-store
+# mssql_tproch_buildschema.t2.tcl.
+
+puts "SETTING CONFIGURATION"
+dbset db mssqls
+dbset bm TPC-H
+
+diset connection mssqls_tcp true
+diset connection mssqls_port 1433
+diset connection mssqls_azure false
+diset connection mssqls_encrypt_connection true
+diset connection mssqls_trust_server_cert true
+diset connection mssqls_authentication windows
+diset connection mssqls_server {(local)}
+diset connection mssqls_linux_server mssql_container
+diset connection mssqls_uid sa
+diset connection mssqls_pass Hammerdb_2024
+diset connection mssqls_linux_authent sql
+diset connection mssqls_linux_odbc {ODBC Driver 18 for SQL Server}
+
+diset tpch mssqls_scale_fact 1
+diset tpch mssqls_maxdop 4
+diset tpch mssqls_num_tpch_threads 4
+diset tpch mssqls_tpch_dbase tpch
+diset tpch mssqls_colstore true
+# load via INSERTs, not bcp: the hammerdb image has the ODBC driver but no bcp binary
+diset tpch mssqls_tpch_use_bcp false
+
+puts "SCHEMA BUILD STARTED"
+buildschema
+puts "SCHEMA BUILD COMPLETED"

--- a/db/mssql/tpch/mssql_tproch_run.t2.tcl
+++ b/db/mssql/tpch/mssql_tproch_run.t2.tcl
@@ -1,0 +1,38 @@
+#!/bin/tclsh
+# maintainer: Pooja Jain
+# T2 (workload-aware) variant of mssql_tproch_run.tcl: raises MAXDOP from 2 to 4
+# (= the container's core count) for the analytical query run. Used by both the
+# common (row-store) and the columnar (t2col) SQL Server T2 scenarios.
+
+puts "SETTING CONFIGURATION"
+dbset db mssqls
+dbset bm TPC-H
+
+diset connection mssqls_tcp true
+diset connection mssqls_port 1433
+diset connection mssqls_azure false
+diset connection mssqls_encrypt_connection true
+diset connection mssqls_trust_server_cert true
+diset connection mssqls_authentication windows
+diset connection mssqls_server {(local)}
+diset connection mssqls_linux_server mssql_container
+diset connection mssqls_uid sa
+diset connection mssqls_pass Hammerdb_2024
+diset connection mssqls_linux_authent sql
+diset connection mssqls_linux_odbc {ODBC Driver 18 for SQL Server}
+
+diset tpch mssqls_scale_fact 1
+diset tpch mssqls_maxdop 4
+diset tpch mssqls_tpch_dbase tpch
+diset tpch mssqls_total_querysets 1
+
+loadscript
+puts "TEST STARTED"
+vuset vu 1
+vucreate
+set jobid [ vurun ]
+vudestroy
+puts "TEST COMPLETE"
+set of [ open /tmp/mssql_tproch w ]
+puts $of $jobid
+close $of

--- a/db/oracle/tpch/oracle_tproch_run.t2.tcl
+++ b/db/oracle/tpch/oracle_tproch_run.t2.tcl
@@ -1,0 +1,32 @@
+#!/bin/tclsh
+# maintainer: Pooja Jain
+# T2 (workload-aware) variant of oracle_tproch_run.tcl: raises the query parallel
+# degree from 2 to 4. NOTE: Oracle Database Free is capped at ~2 CPU threads, so
+# the effective degree is bounded by the edition regardless of this setting.
+
+puts "SETTING CONFIGURATION"
+dbset db ora
+dbset bm TPC-H
+
+diset connection system_user system
+diset connection system_password oracle
+diset connection instance oracle_container:1521/FREEPDB1
+
+diset tpch scale_fact 1
+diset tpch num_tpch_threads 4
+diset tpch tpch_user tpch
+diset tpch tpch_pass tpch
+diset tpch tpch_def_tab users
+diset tpch total_querysets 1
+diset tpch degree_of_parallel 4
+
+loadscript
+puts "TEST STARTED"
+vuset vu 1
+vucreate
+set jobid [ vurun ]
+vudestroy
+puts "TEST COMPLETE"
+set of [ open /tmp/oracle_tproch w ]
+puts $of $jobid
+close $of

--- a/db/pg/tpch/pg_tproch_run.t2.tcl
+++ b/db/pg/tpch/pg_tproch_run.t2.tcl
@@ -1,0 +1,31 @@
+#!/bin/tclsh
+# maintainer: Pooja Jain
+# T2 (workload-aware) variant of pg_tproch_run.tcl: raises the per-query parallel
+# degree from 2 to 4 (= the container's core count) for the analytical workload.
+# Everything else is identical to T0.
+
+puts "SETTING CONFIGURATION"
+dbset db pg
+dbset bm TPC-H
+
+diset connection pg_host postgres_container
+diset connection pg_port 5432
+diset connection pg_sslmode disable
+
+diset tpch pg_scale_fact 1
+diset tpch pg_tpch_user tpch
+diset tpch pg_tpch_pass tpch
+diset tpch pg_tpch_dbase tpch
+diset tpch pg_total_querysets 1
+diset tpch pg_degree_of_parallel 4
+
+loadscript
+puts "TEST STARTED"
+vuset vu 1
+vucreate
+set jobid [ vurun ]
+vudestroy
+puts "TEST COMPLETE"
+set of [ open /tmp/pg_tproch w ]
+puts $of $jobid
+close $of

--- a/run_on_cluster.py
+++ b/run_on_cluster.py
@@ -24,6 +24,9 @@ Examples:
   # Only the TPC-H Postgres scenario, with a completion email
   ./run_on_cluster.py --api-key YOUR_TOKEN --machine-id 42 \
       --filter 'tpch/pg.yml' --email you@example.com
+
+  # Only unoptimized scenarios
+  ./run_on_cluster.py --api-key YOUR_TOKEN --machine-id 42 -t 0 -n
 """
 
 from __future__ import annotations
@@ -158,6 +161,20 @@ def discover_scenarios(repo: Path) -> list[Path]:
     return scenarios
 
 
+def scenario_tier(rel_path: Path) -> str:
+    """Return the tuning tier for a scenario path: 0, 1, or 2.
+
+    Tier 2 includes the common ``.t2.yml`` files and the ``.t2col.yml`` columnar
+    sub-tier, because both represent workload-aware optimization beyond T1.
+    """
+    name = rel_path.name
+    if name.endswith(".t1.yml"):
+        return "1"
+    if name.endswith(".t2.yml") or name.endswith(".t2col.yml"):
+        return "2"
+    return "0"
+
+
 def build_name(prefix: str, rel_path: Path, branch: str) -> str:
     """A useful, unambiguous run name, e.g. 'DBMS-bench tpcc/pg'."""
     benchmark = rel_path.parent.name  # tpcc / tpch (drop the benchmarks/ prefix)
@@ -244,6 +261,12 @@ def build_parser(submit_mod: ModuleType) -> argparse.ArgumentParser:
         "(e.g. 'tpch/*.yml' or 'tpcc/pg.yml').",
     )
     p.add_argument(
+        "-t",
+        "--tier",
+        choices=("0", "1", "2"),
+        help="Only submit one tuning tier: 0=unoptimized base, 1=T1, 2=T2/T2+.",
+    )
+    p.add_argument(
         "--api-url",
         default=os.getenv("GMT_API_URL", "https://api.green-coding.io/").strip(),
         help="Base GMT API URL.",
@@ -308,6 +331,8 @@ def main() -> None:
 
     scenarios = discover_scenarios(repo)
     rel_scenarios = [s.relative_to(repo) for s in scenarios]
+    if args.tier is not None:
+        rel_scenarios = [r for r in rel_scenarios if scenario_tier(r) == args.tier]
     if args.filter:
         # Match against the full repo-relative path (benchmarks/tpcc/pg.yml) as well
         # as the benchmarks-relative path (tpcc/pg.yml), so either form works.
@@ -318,7 +343,12 @@ def main() -> None:
 
         rel_scenarios = [r for r in rel_scenarios if _matches(r)]
     if not rel_scenarios:
-        suffix = f" matching '{args.filter}'" if args.filter else ""
+        filters = []
+        if args.tier is not None:
+            filters.append(f"tier {args.tier}")
+        if args.filter:
+            filters.append(f"'{args.filter}'")
+        suffix = " matching " + " and ".join(filters) if filters else ""
         fail("no usage scenarios found to submit" + suffix)
 
     print(f"Repo:     {repo_url}")
@@ -326,6 +356,8 @@ def main() -> None:
     print(f"Machine:  {args.machine_id}")
     print(f"Schedule: {args.schedule_mode}")
     print(f"API:      {args.api_url.rstrip('/')}")
+    if args.tier is not None:
+        print(f"Tier:     T{args.tier}")
     print(f"Scenarios ({len(rel_scenarios)}):")
     for rel in rel_scenarios:
         print(f"  - {rel.as_posix():<28} -> {build_name(name_prefix, rel, branch)}")


### PR DESCRIPTION
Split of #20 — part 2 of 2. Adds the tuning tiers on top of the default-configuration scenarios.

> **Stacked on #21.** Base is `new-dbs-and-benchmarks`, so the diff here is tuning only. GitHub will retarget this to `main` automatically once #21 merges.

## The tiers

Tier files sit next to the default and share its flow, so only the *engine configuration* varies between them and `run_on_cluster.py` discovers them automatically.

| Tier | File | What changes |
|------|------|--------------|
| T0 | `<db>.yml` | Stock container (shipped in #21) |
| T1 | `<db>.t1.yml` | Each vendor's own rules-of-thumb sized to the fixed 4-CPU / 8-GB container; durability left at default, so the T0→T1 delta is pure resource sizing |
| T2 | `<db>.t2.yml` | Workload-aware indexes, partitioning and parallelism plus curated config |
| T2+ | `<db>.t2col.yml` | Columnar sub-tier — SQL Server columnstore and Db2 BLU on TPC-H |

`TUNING.md` documents the ladder, how each number is derived per engine, its provenance, and the threats to validity (Oracle Free / Db2 Community edition caps, OOM headroom, Oracle/Db2 verify-on-first-run).

## Tooling changes

- `run_on_cluster.py` gains `-t/--tier` to submit a single tier (`-t 0` for every default, `-t 1` for every T1, …).
- `check_repo.py` compares fairness knobs *within* a tier rather than across all driver scripts, since tier variants deliberately change tuning knobs. A sub-tier inherits knobs it doesn't restate from the engine's base tier, so the comparison is on the effective config.
- `check_repo.py` adds check 4: per engine, the T1 tuning payload must be byte-identical across benchmarks, comments included. T1 is hardware-sized and workload-agnostic, so a per-benchmark difference is drift — and a missing comment loses the provenance a reviewer needs to reproduce the number.

`check_repo.py` passes on this branch with 2 expected warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)